### PR TITLE
remove unneeded namespace-syntax-introduce

### DIFF
--- a/racketscript-compiler/racketscript/compiler/expand.rkt
+++ b/racketscript-compiler/racketscript/compiler/expand.rkt
@@ -329,7 +329,7 @@
   ;; work
 
   (parameterize ([current-namespace (make-base-namespace)])
-    (namespace-syntax-introduce (expand stx))))
+    (expand stx)))
 
 ;;; Read modules
 


### PR DESCRIPTION
Not 100% sure but `expand` [seems to already apply `namespace-syntax-introduce`](http://docs.racket-lang.org/reference/Expanding_Top-Level_Forms.html?q=expand#%28def._%28%28quote._~23~25kernel%29._expand%29%29)?

All the tests still pass if we take it out, and other example programs seem to work as well.