### PR TITLE
add remaining (currently supported) list tests

### DIFF
--- a/racketscript-compiler/racketscript/compiler/runtime/core/numbers.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/numbers.js
@@ -5,7 +5,7 @@ import * as $ from "./lib.js";
 export function add(...operands) {
     return [].reduce.call(operands, function(a, b) {
 	return a + b
-    });
+    }, 0);
 }
 
 export function sub(...operands) {
@@ -38,7 +38,7 @@ export function div(...operands) {
     }
 }
 
-/* Comparision */
+/* Comparison */
 
 export function compare(cmp, operands) {
     if (operands.length < 2) {

--- a/racketscript-compiler/racketscript/compiler/runtime/core/vector.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/vector.js
@@ -77,7 +77,8 @@ export function make(items, mutable) {
 
 export function makeInit(size, init) {
     let r = new Array(size);
-    return r.fill(init);
+    r.fill(init);
+    return new Vector(r, true);
 }
 
 export function check(v1) {

--- a/racketscript-compiler/racketscript/compiler/runtime/kernel.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/kernel.js
@@ -64,6 +64,10 @@ exports["number?"] = Core.Number.check;
 
 exports["integer?"] = Number.isInteger;
 
+exports["real?"] = function (v) {
+    return Core.Number.check(v);
+}
+
 exports["exact-nonnegative-integer?"] = function (v) {
     return Number.isInteger(v) && v >= 0;
 }
@@ -266,6 +270,7 @@ exports["vector"] = function () {
     return Core.Vector.make(items, true);
 }
 
+// v is optional
 exports["make-vector"] = function (size, v) {
     return Core.Vector.makeInit(size, v || 0);
 }
@@ -286,6 +291,10 @@ exports["vector-ref"] = function (vec, i) {
 exports["vector-set!"] = function (vec, i, v) {
     Core.Vector.check(vec);
     vec.set(i, v);
+}
+
+exports["vector->list"] = function (v) {
+    return Core.Pair.listFromArray(v.items);
 }
 
 /* --------------------------------------------------------------------------*/
@@ -803,7 +812,7 @@ exports["filter"] = function (fn, lst) {
 }
 
 // TODO: more faithfully reproduce Racket sort?
-// Not working due to compile issues with sort in racket/private/list
+// this implements raw-sort from #%kernel, see racket/private/list
 exports["sort9"] = function (lst, cmp) {
     var arr = Core.Pair.listToArray(lst);
     var x2i = new Map();
@@ -1081,13 +1090,17 @@ exports["procedure-arity"] = function (f) {
 }
 exports["eval-jit-enabled"] = function (f) { return true; }
 
+// TODO: add other types of sequences
+// TODO: HO use of sequence fns, eg in-list, not supported yet
 exports["make-sequence"] = function (who, v) {
-    return Core.Values.make([exports["car"],
-			     exports["cdr"],
-			     v,
-			     exports["pair?"],
-			     false,
-			     false]);
+    return Core.Values.make([exports["car"],   // pos -> vals
+		     // uncomment pre-pos-next arg if using Racket >= 6.7.0.4
+			     //false,            // pre-pos-next
+			     exports["cdr"],   // pos-next
+			     v,                // init
+			     exports["pair?"], // pos-cont?
+			     false,            // val-cont?
+			     false]);          //all-cont?
 }
 
 exports["variable-reference-constant?"] = function (x) { return false; }

--- a/racketscript-compiler/racketscript/compiler/runtime/unsafe.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/unsafe.js
@@ -15,3 +15,9 @@ exports["unsafe-cdr"] = (v) => v.tl;
 // Strutures
 
 exports["unsafe-struct-ref"] = (v, k) => v._fields[k];
+
+/* --------------------------------------------------------------------------*/
+// Numbers
+
+exports["unsafe-fx<"] = Core.Number.lt;
+exports["unsafe-fx+"] = Core.Number.add;

--- a/tests/racket-core/list.rkt
+++ b/tests/racket-core/list.rkt
@@ -417,13 +417,13 @@
   (test '(1 2 3) am list '(1 2 3))
   (test '(1 1 2 2 3 3) am (lambda (x) (list x x)) '(1 2 3)))
 
-;; ;; ---------- shuffle ----------
-;; (let loop ([l (reverse '(1 2 4 8 16 32))])
-;;   (define (length+sum l) (list (length l) (apply + l)))
-;;   (define expected (length+sum l))
-;;   (for ([i (in-range 100)])
-;;     (test expected length+sum (shuffle l)))
-;;   (when (pair? l) (loop (cdr l))))
+;; ---------- shuffle ----------
+(let loop ([l (reverse '(1 2 4 8 16 32))])
+  (define (length+sum l) (list (length l) (apply + l)))
+  (define expected (length+sum l))
+  (for ([i (in-range 100)])
+    (test expected length+sum (shuffle l)))
+  (when (pair? l) (loop (cdr l))))
 
 ;; ;; ---------- combinations ----------
 ;; (let ()
@@ -517,28 +517,28 @@
 ;;           x))))
 ;;   (test #t = (count-cons pl) (count-cons (minimize-cons pl))))
 
-;; ;; ---------- argmin & argmax ----------
+;; ---------- argmin & argmax ----------
 
-;; (let ()
+(let ()
 
-;;   (define ((check-regs . regexps) exn)
-;;     (and (exn:fail? exn)
-;;          (andmap (λ (reg) (regexp-match reg (exn-message exn)))
-;;                  regexps)))
+  #;(define ((check-regs . regexps) exn)
+    (and (exn:fail? exn)
+         (andmap (λ (reg) (regexp-match reg (exn-message exn)))
+                 regexps)))
 
-;;   (test 'argmin object-name argmin)
-;;   (test 1 argmin (lambda (x) 0) (list 1))
-;;   (test 1 argmin (lambda (x) x) (list 1 2 3))
-;;   (test 1 argmin (lambda (x) 1) (list 1 2 3))
+  ;(test 'argmin object-name argmin)
+  (test 1 argmin (lambda (x) 0) (list 1))
+  (test 1 argmin (lambda (x) x) (list 1 2 3))
+  (test 1 argmin (lambda (x) 1) (list 1 2 3))
 
-;;   (test 3
-;;         'argmin-makes-right-number-of-calls
-;;         (let ([c 0])
-;;           (argmin (lambda (x) (set! c (+ c 1)) 0)
-;;                   (list 1 2 3))
-;;           c))
+  (test 3
+;        'argmin-makes-right-number-of-calls
+        (let ([c 0])
+          (argmin (lambda (x) (set! c (+ c 1)) 0)
+                  (list 1 2 3))
+          c))
 
-;;   (test '(1 banana) argmin car '((3 pears) (1 banana) (2 apples)))
+  (test '(1 banana) argmin car '((3 pears) (1 banana) (2 apples)))
 
 ;;   (err/rt-test (argmin 1 (list 1)) (check-regs #rx"argmin" #rx"any/c . -> . real[?]"))
 ;;   (err/rt-test (argmin (lambda (x) x) 3) (check-regs #rx"argmin" #rx"list"))
@@ -548,19 +548,19 @@
 ;;   (err/rt-test (argmin (lambda (x) x) (list +i)) (check-regs #rx"argmin" #rx"real"))
 ;;   (err/rt-test (argmin (lambda (x) x) (list)) (check-regs #rx"argmin" #rx".and/c list[?] .not/c empty[?].."))
 
-;;   (test 'argmax object-name argmax)
-;;   (test 1 argmax (lambda (x) 0) (list 1))
-;;   (test 3 argmax (lambda (x) x) (list 1 2 3))
-;;   (test 1 argmax (lambda (x) 1) (list 1 2 3))
+  ;(test 'argmax object-name argmax)
+  (test 1 argmax (lambda (x) 0) (list 1))
+  (test 3 argmax (lambda (x) x) (list 1 2 3))
+  (test 1 argmax (lambda (x) 1) (list 1 2 3))
 
-;;   (test 3
-;;         'argmax-makes-right-number-of-calls
-;;         (let ([c 0])
-;;           (argmax (lambda (x) (set! c (+ c 1)) 0)
-;;                   (list 1 2 3))
-;;           c))
+  (test 3
+;        'argmax-makes-right-number-of-calls
+        (let ([c 0])
+          (argmax (lambda (x) (set! c (+ c 1)) 0)
+                  (list 1 2 3))
+          c))
 
-;;   (test '(3 pears) argmax car '((3 pears) (1 banana) (2 apples)))
+  (test '(3 pears) argmax car '((3 pears) (1 banana) (2 apples)))
 
 ;;   (err/rt-test (argmax 1 (list 1)) (check-regs #rx"argmax" #rx"any/c . -> . real[?]"))
 ;;   (err/rt-test (argmax (lambda (x) x) 3) (check-regs #rx"argmax" #rx"list"))
@@ -569,24 +569,25 @@
 
 ;;   (err/rt-test (argmax (lambda (x) x) (list +i)) (check-regs #rx"argmax" #rx"real?"))
 ;;   (err/rt-test (argmax (lambda (x) x) (list)) (check-regs #rx"argmax" #rx".and/c list[?] .not/c empty[?]..")))
+)
 
-;; ;; ---------- range ----------
+;; ---------- range ----------
 
-;; (let ()
-;;   (test '(0 1 2 3) range 4)
-;;   (test '() range 0)
-;;   (test '(0 1 2 3 4 5 6 7) range 8)
-;;   (test '() range 3 2)
-;;   (test '(3) range 3 2 -1)
-;;   (test '(3 4 5 6 7 8) range 3 9)
-;;   (test '(3 5 7) range 3 9 2)
-;;   (test '(3 3.5 4.0 4.5 5.0 5.5 6.0 6.5 7.0 7.5 8.0 8.5) range 3 9 0.5)
-;;   (test '(9 7 5) range 9 3 -2)
-;;   (test '(0 1 2 3 4 5 6 7 8 9) range 10)
-;;   (test '(10 11 12 13 14 15 16 17 18 19) range 10 20)
-;;   (test '(20 22 24 26 28 30 32 34 36 38) range 20 40 2)
-;;   (test '(20 19 18 17 16 15 14 13 12 11) range 20 10 -1)
-;;   (test '(10 11.5 13.0 14.5) range 10 15 1.5))
+(let ()
+  (test '(0 1 2 3) range 4)
+  (test '() range 0)
+  (test '(0 1 2 3 4 5 6 7) range 8)
+  (test '() range 3 2)
+  (test '(3) range 3 2 -1)
+  (test '(3 4 5 6 7 8) range 3 9)
+  (test '(3 5 7) range 3 9 2)
+  (test '(3 3.5 4.0 4.5 5.0 5.5 6.0 6.5 7.0 7.5 8.0 8.5) range 3 9 0.5)
+  (test '(9 7 5) range 9 3 -2)
+  (test '(0 1 2 3 4 5 6 7 8 9) range 10)
+  (test '(10 11 12 13 14 15 16 17 18 19) range 10 20)
+  (test '(20 22 24 26 28 30 32 34 36 38) range 20 40 2)
+  (test '(20 19 18 17 16 15 14 13 12 11) range 20 10 -1)
+  (test '(10 11.5 13.0 14.5) range 10 15 1.5))
 
 ;; ;; ---------- group-by ----------
 
@@ -603,106 +604,106 @@
 ;; (err/rt-test (group-by '() #f))
 ;; (err/rt-test (group-by '() values #f))
 
-;; ;; ---------- cartesian-product ----------
+;; ---------- cartesian-product ----------
 
-;; (test '((1 a) (1 b) (1 c)
-;;         (2 a) (2 b) (2 c)
-;;         (3 a) (3 b) (3 c))
-;;       cartesian-product '(1 2 3) '(a b c))
-;; (test '((4 d #t) (4 d #f) (4 e #t) (4 e #f) (4 f #t) (4 f #f)
-;;         (5 d #t) (5 d #f) (5 e #t) (5 e #f) (5 f #t) (5 f #f)
-;;         (6 d #t) (6 d #f) (6 e #t) (6 e #f) (6 f #t) (6 f #f))
-;;       cartesian-product '(4 5 6) '(d e f) '(#t #f))
+(test '((1 a) (1 b) (1 c)
+        (2 a) (2 b) (2 c)
+        (3 a) (3 b) (3 c))
+      cartesian-product '(1 2 3) '(a b c))
+(test '((4 d #t) (4 d #f) (4 e #t) (4 e #f) (4 f #t) (4 f #f)
+        (5 d #t) (5 d #f) (5 e #t) (5 e #f) (5 f #t) (5 f #f)
+        (6 d #t) (6 d #f) (6 e #t) (6 e #f) (6 f #t) (6 f #f))
+      cartesian-product '(4 5 6) '(d e f) '(#t #f))
 ;; (err/rt-test (cartesian-product 3))
 
-;; ;; ---------- list-update ----------
+;; ---------- list-update ----------
 
-;; (test '("zero" one two) list-update '(zero one two) 0 symbol->string)
-;; (test '(zero "one" two) list-update '(zero one two) 1 symbol->string)
+(test '("zero" one two) list-update '(zero one two) 0 symbol->string)
+(test '(zero "one" two) list-update '(zero one two) 1 symbol->string)
 ;; (err/rt-test (list-update '(zero one two) 3 symbol->string))
 ;; (err/rt-test (list-update '(zero one two) -1 symbol->string))
 ;; (err/rt-test (list-update '(zero one two) #f symbol->string))
 ;; (err/rt-test (list-update #f 0 symbol->string))
 ;; (err/rt-test (list-update '(zero one two) 0 #f))
 
-;; ;; ---------- list-set ----------
+;; ---------- list-set ----------
 
-;; (test '(zero one "two") list-set '(zero one two) 2 "two")
+(test '(zero one "two") list-set '(zero one two) 2 "two")
 ;; (err/rt-test (list-set '(zero one two) 3 "two"))
 ;; (err/rt-test (list-set '(zero one two) -1 "two"))
 ;; (err/rt-test (list-set '(zero one two) #f "two"))
 
-;; ;; ---------- list prefix functions ----------
+;; ---------- list prefix functions ----------
 
-;; (test #t list-prefix? '(1 2) '(1 2 3 4 5))
-;; (test #f list-prefix? '(2 1) '(1 2 3 4 5))
-;; (test #t list-prefix? '(1 2) '(1 2 3 4 5) =)
-;; (test #f list-prefix? '(2 1) '(1 2 3 4 5) =)
+(test #t list-prefix? '(1 2) '(1 2 3 4 5))
+(test #f list-prefix? '(2 1) '(1 2 3 4 5))
+(test #t list-prefix? '(1 2) '(1 2 3 4 5) =)
+(test #f list-prefix? '(2 1) '(1 2 3 4 5) =)
 ;; (err/rt-test (list-prefix? #t '()))
 ;; (err/rt-test (list-prefix? '() #t))
-;; (test '(a b) take-common-prefix '(a b c d) '(a b x y z))
-;; (test '() take-common-prefix '(1 a b c d) '(a b x y z))
-;; (test '(a b c d) take-common-prefix '(a b c d) '(a b c d))
-;; (test '(1 2) take-common-prefix '(1 2 3 4) '(1 2 4 3) =)
+(test '(a b) take-common-prefix '(a b c d) '(a b x y z))
+(test '() take-common-prefix '(1 a b c d) '(a b x y z))
+(test '(a b c d) take-common-prefix '(a b c d) '(a b c d))
+(test '(1 2) take-common-prefix '(1 2 3 4) '(1 2 4 3) =)
 ;; (err/rt-test (take-common-prefix '() '() #f))
-;; (define (drop*-list xs ys [=? equal?])
-;;   (define-values (a b)
-;;     (drop-common-prefix xs ys =?))
-;;   (list a b))
-;; (test '((c d) (x y z)) drop*-list '(a b c d) '(a b x y z))
-;; (test '((1 a b c d) (a b x y z)) drop*-list '(1 a b c d) '(a b x y z))
-;; (test '(() ()) drop*-list '(a b c d) '(a b c d))
-;; (test '((3 4) (4 3)) drop*-list '(1 2 3 4) '(1 2 4 3) =)
+(define (drop*-list xs ys [=? equal?])
+  (define-values (a b)
+    (drop-common-prefix xs ys =?))
+  (list a b))
+(test '((c d) (x y z)) drop*-list '(a b c d) '(a b x y z))
+(test '((1 a b c d) (a b x y z)) drop*-list '(1 a b c d) '(a b x y z))
+(test '(() ()) drop*-list '(a b c d) '(a b c d))
+(test '((3 4) (4 3)) drop*-list '(1 2 3 4) '(1 2 4 3) =)
 ;; (err/rt-test (drop*-list '() '() #f))
-;; (define (split*-list xs ys [=? equal?])
-;;   (define-values (a b c)
-;;     (split-common-prefix xs ys =?))
-;;   (list a b c))
-;; (test '((a b) (c d) (x y z)) split*-list '(a b c d) '(a b x y z))
-;; (test '(() (1 a b c d) (a b x y z)) split*-list '(1 a b c d) '(a b x y z))
-;; (test '((a b c d) () ()) split*-list '(a b c d) '(a b c d))
-;; (test '((1 2) (3 4) (4 3)) split*-list '(1 2 3 4) '(1 2 4 3) =)
+(define (split*-list xs ys [=? equal?])
+  (define-values (a b c)
+    (split-common-prefix xs ys =?))
+  (list a b c))
+(test '((a b) (c d) (x y z)) split*-list '(a b c d) '(a b x y z))
+(test '(() (1 a b c d) (a b x y z)) split*-list '(1 a b c d) '(a b x y z))
+(test '((a b c d) () ()) split*-list '(a b c d) '(a b c d))
+(test '((1 2) (3 4) (4 3)) split*-list '(1 2 3 4) '(1 2 4 3) =)
 ;; (err/rt-test (split*-list '() '() #f))
 ;; (err/rt-test (take-common-prefix 1 1))
 
-;; ;; ---------- remf / remf* ----------
+;; ---------- remf / remf* ----------
 
-;; (test '() remf positive? '())
-;; (test '(-2 3 4 -5) remf positive? '(1 -2 3 4 -5))
-;; (test '(1 3 4 -5) remf even? '(1 -2 3 4 -5))
-;; (test '(1 -2 3 4 -5) remf (λ (x) #f) '(1 -2 3 4 -5))
-;; (test '() remf* positive? '())
-;; (test '(-2 -5) remf* positive? '(1 -2 3 4 -5))
-;; (test '(1 3 -5) remf* even? '(1 -2 3 4 -5))
-;; (test '(1 -2 3 4 -5) remf* (λ (x) #f) '(1 -2 3 4 -5))
+(test '() remf positive? '())
+(test '(-2 3 4 -5) remf positive? '(1 -2 3 4 -5))
+(test '(1 3 4 -5) remf even? '(1 -2 3 4 -5))
+(test '(1 -2 3 4 -5) remf (λ (x) #f) '(1 -2 3 4 -5))
+(test '() remf* positive? '())
+(test '(-2 -5) remf* positive? '(1 -2 3 4 -5))
+(test '(1 3 -5) remf* even? '(1 -2 3 4 -5))
+(test '(1 -2 3 4 -5) remf* (λ (x) #f) '(1 -2 3 4 -5))
 
-;; ;; ---------- index(es)-of / index(es)-where ----------
+;; ---------- index(es)-of / index(es)-where ----------
 
-;; (test #f index-of '() 'a)
-;; (test #f index-of '(a b) 'c)
-;; (test 0 index-of '(a b c) 'a)
-;; (test 1 index-of '(a b c) 'b)
-;; (test 0 index-of (list #'a #'b #'c) #'a free-identifier=?)
-;; (test 1 index-of (list #'a #'b #'c) #'b free-identifier=?)
+(test #f index-of '() 'a)
+(test #f index-of '(a b) 'c)
+(test 0 index-of '(a b c) 'a)
+(test 1 index-of '(a b c) 'b)
+;(test 0 index-of (list #'a #'b #'c) #'a free-identifier=?)
+;(test 1 index-of (list #'a #'b #'c) #'b free-identifier=?)
 
-;; (test #f index-where '() even?)
-;; (test #f index-where '(1 3 5) even?)
-;; (test 0 index-where '(1 2 3 4 5) odd?)
-;; (test 1 index-where '(1 2 3 4 5) even?)
+(test #f index-where '() even?)
+(test #f index-where '(1 3 5) even?)
+(test 0 index-where '(1 2 3 4 5) odd?)
+(test 1 index-where '(1 2 3 4 5) even?)
 
-;; (test '() indexes-of '() 'a)
-;; (test '() indexes-of '(a b) 'c)
-;; (test '(0) indexes-of '(a b c) 'a)
-;; (test '(1) indexes-of '(a b c) 'b)
-;; (test '(0 1) indexes-of '(a a b) 'a)
-;; (test '(1 2) indexes-of '(a b b) 'b)
-;; (test '(0 1 2) indexes-of '(a a a) 'a)
+(test '() indexes-of '() 'a)
+(test '() indexes-of '(a b) 'c)
+(test '(0) indexes-of '(a b c) 'a)
+(test '(1) indexes-of '(a b c) 'b)
+(test '(0 1) indexes-of '(a a b) 'a)
+(test '(1 2) indexes-of '(a b b) 'b)
+(test '(0 1 2) indexes-of '(a a a) 'a)
 ;; (test '(0 1) indexes-of (list #'a #'a #'b) #'a free-identifier=?)
 ;; (test '(1 2) indexes-of (list #'a #'b #'b) #'b free-identifier=?)
 
-;; (test '() indexes-where '() even?)
-;; (test '() indexes-where '(1 3 5) even?)
-;; (test '(1 3) indexes-where '(1 2 3 4 5) even?)
-;; (test '(0 2 4) indexes-where '(1 2 3 4 5) odd?)
+(test '() indexes-where '() even?)
+(test '() indexes-where '(1 3 5) even?)
+(test '(1 3) indexes-where '(1 2 3 4 5) even?)
+(test '(0 2 4) indexes-where '(1 2 3 4 5) odd?)
 
 ;; (report-errs)

--- a/tests/racket-core/racket-list.rkt
+++ b/tests/racket-core/racket-list.rkt
@@ -5,23 +5,23 @@
 ;; We copy it here bc Racketscript currently does not know where to find Racket
 ;; collects, but we still want to test that this file properly compiles.
 
-(provide ;first second third fourth fifth sixth seventh eighth ninth tenth
+(provide first second third fourth fifth sixth seventh eighth ninth tenth
 
-         last-pair last ; rest
+         last-pair last rest
 
-         ;; cons?
-         ;; empty
-         ;; empty?
+         cons?
+         empty
+         empty?
 
          make-list
 
-         ;; list-update
-         ;; list-set
+         list-update
+         list-set
 
-         ;; index-of
-         ;; index-where
-         ;; indexes-of
-         ;; indexes-where
+         index-of
+         index-where
+         indexes-of
+         indexes-where
 
          drop
          take
@@ -36,10 +36,10 @@
          dropf-right
          splitf-at-right
 
-         ;; list-prefix?
-         ;; split-common-prefix
-         ;; take-common-prefix
-         ;; drop-common-prefix
+         list-prefix?
+         split-common-prefix
+         take-common-prefix
+         drop-common-prefix
 
          append*
          flatten
@@ -50,49 +50,49 @@
          count
          partition
 
-         ;; ;; convenience
-         ;; range
+         ;; convenience
+         range
          append-map
          filter-not
-         ;; shuffle
+         shuffle
          ;; combinations
          ;; in-combinations
          ;; permutations
          ;; in-permutations
-         ;; argmin
-         ;; argmax
+         argmin
+         argmax
          ;; group-by
-         ;; cartesian-product
-         ;; remf
-         ;; remf*
+         cartesian-product
+         remf
+         remf*
 )
 
-;; (define (first x)
-;;   (if (and (pair? x) (list? x))
-;;     (car x)
-;;     (raise-argument-error 'first "(and/c list? (not/c empty?))" x)))
+(define (first x)
+  (if (and (pair? x) (list? x))
+    (car x)
+    (raise-argument-error 'first "(and/c list? (not/c empty?))" x)))
 
-;; (define-syntax define-lgetter
-;;   (syntax-rules ()
-;;     [(_ name npos)
-;;      (define (name l0)
-;;        (if (list? l0)
-;;          (let loop ([l l0] [pos npos])
-;;            (if (pair? l)
-;;              (if (eq? pos 1) (car l) (loop (cdr l) (sub1 pos)))
-;;              (raise-arguments-error 'name
-;;                                     "list contains too few elements"
-;;                                     "list" l0)))
-;;          (raise-argument-error 'name "list?" l0)))]))
-;; (define-lgetter second  2)
-;; (define-lgetter third   3)
-;; (define-lgetter fourth  4)
-;; (define-lgetter fifth   5)
-;; (define-lgetter sixth   6)
-;; (define-lgetter seventh 7)
-;; (define-lgetter eighth  8)
-;; (define-lgetter ninth   9)
-;; (define-lgetter tenth   10)
+(define-syntax define-lgetter
+  (syntax-rules ()
+    [(_ name npos)
+     (define (name l0)
+       (if (list? l0)
+         (let loop ([l l0] [pos npos])
+           (if (pair? l)
+             (if (eq? pos 1) (car l) (loop (cdr l) (sub1 pos)))
+             (raise-arguments-error 'name
+                                    "list contains too few elements"
+                                    "list" l0)))
+         (raise-argument-error 'name "list?" l0)))]))
+(define-lgetter second  2)
+(define-lgetter third   3)
+(define-lgetter fourth  4)
+(define-lgetter fifth   5)
+(define-lgetter sixth   6)
+(define-lgetter seventh 7)
+(define-lgetter eighth  8)
+(define-lgetter ninth   9)
+(define-lgetter tenth   10)
 
 (define (last-pair l)
   (if (pair? l)
@@ -110,14 +110,14 @@
         (car l)))
     (raise-argument-error 'last "(and/c list? (not/c empty?))" l)))
 
-;; (define (rest l)
-;;   (if (and (pair? l) (list? l))
-;;     (cdr l)
-;;     (raise-argument-error 'rest "(and/c list? (not/c empty?))" l)))
+(define (rest l)
+  (if (and (pair? l) (list? l))
+    (cdr l)
+    (raise-argument-error 'rest "(and/c list? (not/c empty?))" l)))
 
-;; (define (cons? l) (pair? l))
-;; (define (empty? l) (null? l))
-;; (define empty '())
+(define (cons? l) (pair? l))
+(define (empty? l) (null? l))
+(define empty '())
 
 (define (make-list n x)
   (unless (exact-nonnegative-integer? n)
@@ -125,24 +125,24 @@
   (let loop ([n n] [r '()])
     (if (zero? n) r (loop (sub1 n) (cons x r)))))
 
-;; (define (list-update l i f)
-;;   (unless (list? l)
-;;     (raise-argument-error 'list-update "list?" 0 l i f))
-;;   (unless (exact-nonnegative-integer? i)
-;;     (raise-argument-error 'list-update "exact-nonnegative-integer?" 1 l i f))
-;;   (unless (and (procedure? f)
-;;                (procedure-arity-includes? f 1))
-;;     (raise-argument-error 'list-update "(-> any/c any/c)" 2 l i f))
-;;   (cond
-;;    [(zero? i) (cons (f (car l)) (cdr l))]
-;;    [else (cons (car l) (list-update (cdr l) (sub1 i) f))]))
+(define (list-update l i f)
+  (unless (list? l)
+    (raise-argument-error 'list-update "list?" 0 l i f))
+  (unless (exact-nonnegative-integer? i)
+    (raise-argument-error 'list-update "exact-nonnegative-integer?" 1 l i f))
+  (unless (and (procedure? f)
+               (procedure-arity-includes? f 1))
+    (raise-argument-error 'list-update "(-> any/c any/c)" 2 l i f))
+  (cond
+   [(zero? i) (cons (f (car l)) (cdr l))]
+   [else (cons (car l) (list-update (cdr l) (sub1 i) f))]))
 
-;; (define (list-set l k v)
-;;   (unless (list? l)
-;;     (raise-argument-error 'list-set "list?" 0 l k v))
-;;   (unless (exact-nonnegative-integer? k)
-;;     (raise-argument-error 'list-set "exact-nonnegative-integer?" 1 l k v))
-;;   (list-update l k (lambda (_) v)))
+(define (list-set l k v)
+  (unless (list? l)
+    (raise-argument-error 'list-set "list?" 0 l k v))
+  (unless (exact-nonnegative-integer? k)
+    (raise-argument-error 'list-set "exact-nonnegative-integer?" 1 l k v))
+  (list-update l k (lambda (_) v)))
 
 ;; internal use below
 (define (drop* list n) ; no error checking, returns #f if index is too large
@@ -277,54 +277,54 @@
 (define (splitf-at-right list pred)
   (split-at list (count-from-right 'splitf-at-right list pred)))
 
-;; ; list-prefix? : list? list? -> boolean?
-;; ; Is l a prefix or r?
-;; (define (list-prefix? ls rs [same? equal?])
-;;   (unless (list? ls)
-;;     (raise-argument-error 'list-prefix? "list?" 0 ls rs))
-;;   (unless (list? rs)
-;;     (raise-argument-error 'list-prefix? "list?" 1 ls rs))
-;;   (unless (and (procedure? same?)
-;;                (procedure-arity-includes? same? 2))
-;;     (raise-argument-error 'list-prefix? "(any/c any/c . -> . any/c)" 2 ls rs same?))
-;;   (or (null? ls)
-;;       (and (pair? rs)
-;;            (same? (car ls) (car rs))
-;;            (list-prefix? (cdr ls) (cdr rs)))))
+; list-prefix? : list? list? -> boolean?
+; Is l a prefix or r?
+(define (list-prefix? ls rs [same? equal?])
+  (unless (list? ls)
+    (raise-argument-error 'list-prefix? "list?" 0 ls rs))
+  (unless (list? rs)
+    (raise-argument-error 'list-prefix? "list?" 1 ls rs))
+  (unless (and (procedure? same?)
+               (procedure-arity-includes? same? 2))
+    (raise-argument-error 'list-prefix? "(any/c any/c . -> . any/c)" 2 ls rs same?))
+  (or (null? ls)
+      (and (pair? rs)
+           (same? (car ls) (car rs))
+           (list-prefix? (cdr ls) (cdr rs)))))
 
-;; ;; Eli: How about a version that removes the equal prefix from two lists
-;; ;; and returns the tails -- this way you can tell if they're equal, or
-;; ;; one is a prefix of the other, or if there was any equal prefix at
-;; ;; all.  (Which can be useful for things like making a path relative to
-;; ;; another path.)  A nice generalization is to make it get two or more
-;; ;; lists, and return a matching number of values.
+;; Eli: How about a version that removes the equal prefix from two lists
+;; and returns the tails -- this way you can tell if they're equal, or
+;; one is a prefix of the other, or if there was any equal prefix at
+;; all.  (Which can be useful for things like making a path relative to
+;; another path.)  A nice generalization is to make it get two or more
+;; lists, and return a matching number of values.
 
-;; (define (internal-split-common-prefix as bs same? keep-prefix? name)
-;;   (unless (list? as)
-;;     (raise-argument-error name "list?" 0 as bs))
-;;   (unless (list? bs)
-;;     (raise-argument-error name "list?" 1 as bs))
-;;   (unless (and (procedure? same?)
-;;                (procedure-arity-includes? same? 2))
-;;     (raise-argument-error name "(any/c any/c . -> . any/c)" 2 as bs same?))
-;;   (let loop ([as as] [bs bs])
-;;     (if (and (pair? as) (pair? bs) (same? (car as) (car bs)))
-;;         (let-values ([(prefix atail btail) (loop (cdr as) (cdr bs))])
-;;           (values (and keep-prefix? (cons (car as) prefix)) atail btail))
-;;         (values null as bs))))
+(define (internal-split-common-prefix as bs same? keep-prefix? name)
+  (unless (list? as)
+    (raise-argument-error name "list?" 0 as bs))
+  (unless (list? bs)
+    (raise-argument-error name "list?" 1 as bs))
+  (unless (and (procedure? same?)
+               (procedure-arity-includes? same? 2))
+    (raise-argument-error name "(any/c any/c . -> . any/c)" 2 as bs same?))
+  (let loop ([as as] [bs bs])
+    (if (and (pair? as) (pair? bs) (same? (car as) (car bs)))
+        (let-values ([(prefix atail btail) (loop (cdr as) (cdr bs))])
+          (values (and keep-prefix? (cons (car as) prefix)) atail btail))
+        (values null as bs))))
 
-;; (define (split-common-prefix as bs [same? equal?])
-;;   (internal-split-common-prefix as bs same? #t 'split-common-prefix))
+(define (split-common-prefix as bs [same? equal?])
+  (internal-split-common-prefix as bs same? #t 'split-common-prefix))
 
-;; (define (take-common-prefix as bs [same? equal?])
-;;   (let-values ([(prefix atail btail)
-;;                 (internal-split-common-prefix as bs same? #t 'take-common-prefix)])
-;;     prefix))
+(define (take-common-prefix as bs [same? equal?])
+  (let-values ([(prefix atail btail)
+                (internal-split-common-prefix as bs same? #t 'take-common-prefix)])
+    prefix))
 
-;; (define (drop-common-prefix as bs [same? equal?])
-;;   (let-values ([(prefix atail btail)
-;;                 (internal-split-common-prefix as bs same? #f 'drop-common-prefix)])
-;;     (values atail btail)))
+(define (drop-common-prefix as bs [same? equal?])
+  (let-values ([(prefix atail btail)
+                (internal-split-common-prefix as bs same? #f 'drop-common-prefix)])
+    (values atail btail)))
 
 (define append*
   (case-lambda [(ls) (apply append ls)] ; optimize common case
@@ -339,7 +339,7 @@
           [(pair? sexp) (loop (car sexp) (loop (cdr sexp) acc))]
           [else (cons sexp acc)])))
 
-;; ;; General note: many non-tail recursive, which are just as fast in racket
+;; General note: many non-tail recursive, which are just as fast in racket
 
 #;(define (add-between l x
                      #:splice? [splice? #f]
@@ -566,12 +566,12 @@
       (let ([x (car l)] [l (cdr l)])
         (if (pred x) (loop l (cons x i) o) (loop l i (cons x o)))))))
 
-;; ;; similar to in-range, but returns a list
-;; (define range
-;;   (case-lambda
-;;     [(end)            (for/list ([i (in-range end)])            i)]
-;;     [(start end)      (for/list ([i (in-range start end)])      i)]
-;;     [(start end step) (for/list ([i (in-range start end step)]) i)]))
+;; similar to in-range, but returns a list
+(define range
+  (case-lambda
+    [(end)            (for/list ([i (in-range end)])            i)]
+    [(start end)      (for/list ([i (in-range start end)])      i)]
+    [(start end step) (for/list ([i (in-range start end step)]) i)]))
 
 (define append-map
   (case-lambda [(f l)      (apply append (map f l))]
@@ -593,14 +593,14 @@
       (reverse result)
       (loop (cdr l) (if (f (car l)) result (cons (car l) result))))))
 
-;; ;; Fisher-Yates Shuffle
-;; (define (shuffle l)
-;;   (define a (make-vector (length l)))
-;;   (for ([x (in-list l)] [i (in-naturals)])
-;;     (define j (random (add1 i)))
-;;     (unless (= j i) (vector-set! a i (vector-ref a j)))
-;;     (vector-set! a j x))
-;;   (vector->list a))
+;; Fisher-Yates Shuffle
+(define (shuffle l)
+  (define a (make-vector (length l)))
+  (for ([x (in-list l)] [i (in-naturals)])
+    (define j (random (add1 i)))
+    (unless (= j i) (vector-set! a i (vector-ref a j)))
+    (vector-set! a j x))
+  (vector->list a))
 
 ;; (define (combinations l [k #f])
 ;;   (for/list ([x (in-combinations l k)]) x))
@@ -727,164 +727,165 @@
 ;;                  [else      #f]))
 ;;          (in-producer (λ() (begin0 cur (set! cur (next)))) #f)]))
 
-;; ;; mk-min : (number number -> boolean) symbol (X -> real) (listof X) -> X
-;; (define (mk-min cmp name f xs)
-;;   (unless (and (procedure? f)
-;;                (procedure-arity-includes? f 1))
-;;     (raise-argument-error name "(any/c . -> . real?)" 0 f xs))
-;;   (unless (and (list? xs)
-;;                (pair? xs))
-;;     (raise-argument-error name "(and/c list? (not/c empty?))" 1 f xs))
-;;   (let ([init-min-var (f (car xs))])
-;;     (unless (real? init-min-var)
-;;       (raise-result-error name "real?" init-min-var))
-;;     (let loop ([min (car xs)]
-;;                [min-var init-min-var]
-;;                [xs (cdr xs)])
-;;       (cond
-;;         [(null? xs) min]
-;;         [else
-;;          (let ([new-min (f (car xs))])
-;;            (unless (real? new-min)
-;;              (raise-result-error name "real?" new-min))
-;;            (cond
-;;              [(cmp new-min min-var)
-;;               (loop (car xs) new-min (cdr xs))]
-;;              [else
-;;               (loop min min-var (cdr xs))]))]))))
-;; (define (argmin f xs) (mk-min < 'argmin f xs))
-;; (define (argmax f xs) (mk-min > 'argmax f xs))
+;; mk-min : (number number -> boolean) symbol (X -> real) (listof X) -> X
+(define (mk-min cmp name f xs)
+  (unless (and (procedure? f)
+               (procedure-arity-includes? f 1))
+    (raise-argument-error name "(any/c . -> . real?)" 0 f xs))
+  (unless (and (list? xs)
+               (pair? xs))
+    (raise-argument-error name "(and/c list? (not/c empty?))" 1 f xs))
+  (let ([init-min-var (f (car xs))])
+    (unless (real? init-min-var)
+      (raise-result-error name "real?" init-min-var))
+    (let loop ([min (car xs)]
+               [min-var init-min-var]
+               [xs (cdr xs)])
+      (cond
+        [(null? xs) min]
+        [else
+         (let ([new-min (f (car xs))])
+           (unless (real? new-min)
+             (raise-result-error name "real?" new-min))
+           (cond
+             [(cmp new-min min-var)
+              (loop (car xs) new-min (cdr xs))]
+             [else
+              (loop min min-var (cdr xs))]))]))))
+(define (argmin f xs) (mk-min < 'argmin f xs))
+(define (argmax f xs) (mk-min > 'argmax f xs))
 
-;; ;; (x -> y) (listof x) [(y y -> bool)] -> (listof (listof x))
-;; ;; groups together elements that are considered equal
-;; ;; =? should be reflexive, transitive and commutative
-;; (define (group-by key l [=? equal?])
+;; (x -> y) (listof x) [(y y -> bool)] -> (listof (listof x))
+;; groups together elements that are considered equal
+;; =? should be reflexive, transitive and commutative
+;; TODO: optional args unsupported?
+#;(define (group-by key l [=? equal?])
 
-;;   (unless (and (procedure? key)
-;;                (procedure-arity-includes? key 1))
-;;     (raise-argument-error 'group-by "(-> any/c any/c)" 0 key l))
-;;   (unless (and (procedure? =?)
-;;                (procedure-arity-includes? =? 2))
-;;     (raise-argument-error 'group-by "(any/c any/c . -> . any/c)" 2 key l =?))
-;;   (unless (list? l)
-;;     (raise-argument-error 'group-by "list?" 1 key l))
+  (unless (and (procedure? key)
+               (procedure-arity-includes? key 1))
+    (raise-argument-error 'group-by "(-> any/c any/c)" 0 key l))
+  (unless (and (procedure? =?)
+               (procedure-arity-includes? =? 2))
+    (raise-argument-error 'group-by "(any/c any/c . -> . any/c)" 2 key l =?))
+  (unless (list? l)
+    (raise-argument-error 'group-by "list?" 1 key l))
 
-;;   ;; like hash-update, but for alists
-;;   (define (alist-update al k up fail)
-;;     (let loop ([al al])
-;;       (cond [(null? al)
-;;              ;; did not find equivalence class, create one
-;;              (list (cons k (up '())))]
-;;             [(=? (car (car al)) k)
-;;              ;; found the right equivalence class
-;;              (cons
-;;               (cons k (up (cdr (car al)))) ; updater takes elements, w/o key
-;;               (cdr al))]
-;;             [else ; keep going
-;;              (cons (car al) (loop (cdr al)))])))
+  ;; like hash-update, but for alists
+  (define (alist-update al k up fail)
+    (let loop ([al al])
+      (cond [(null? al)
+             ;; did not find equivalence class, create one
+             (list (cons k (up '())))]
+            [(=? (car (car al)) k)
+             ;; found the right equivalence class
+             (cons
+              (cons k (up (cdr (car al)))) ; updater takes elements, w/o key
+              (cdr al))]
+            [else ; keep going
+             (cons (car al) (loop (cdr al)))])))
 
-;;   ;; In cases where `=?` is a built-in equality, can use hash tables instead
-;;   ;; of lists to compute equivalence classes.
-;;   (define-values (base update)
-;;     (cond [(equal? =? eq?)    (values (hasheq)  hash-update)]
-;;           [(equal? =? eqv?)   (values (hasheqv) hash-update)]
-;;           [(equal? =? equal?) (values (hash)    hash-update)]
-;;           [else               (values '()       alist-update)]))
+  ;; In cases where `=?` is a built-in equality, can use hash tables instead
+  ;; of lists to compute equivalence classes.
+  (define-values (base update)
+    (cond [(equal? =? eq?)    (values (hasheq)  hash-update)]
+          [(equal? =? eqv?)   (values (hasheqv) hash-update)]
+          [(equal? =? equal?) (values (hash)    hash-update)]
+          [else               (values '()       alist-update)]))
 
-;;   (define classes
-;;     (for/fold ([res base])
-;;         ([elt (in-list l)]
-;;          [idx (in-naturals)]) ; to keep ordering stable
-;;       (define k (key elt))
-;;       (define v (cons idx elt))
-;;       (update res k (lambda (o) (cons v o)) '())))
-;;   (define sorted-classes
-;;     (if (list? classes)
-;;         (for/list ([p (in-list classes)])
-;;           (sort (cdr p) < #:key car))
-;;         (for/list ([(_ c) (in-hash classes)])
-;;           (sort c < #:key car))))
-;;   ;; sort classes by order of first appearance, then remove indices
-;;   (for/list ([c (in-list (sort sorted-classes < #:key caar))])
-;;     (map cdr c)))
+  (define classes
+    (for/fold ([res base])
+        ([elt (in-list l)]
+         [idx (in-naturals)]) ; to keep ordering stable
+      (define k (key elt))
+      (define v (cons idx elt))
+      (update res k (lambda (o) (cons v o)) '())))
+  (define sorted-classes
+    (if (list? classes)
+        (for/list ([p (in-list classes)])
+          (sort (cdr p) < #:key car))
+        (for/list ([(_ c) (in-hash classes)])
+          (sort c < #:key car))))
+  ;; sort classes by order of first appearance, then remove indices
+  (for/list ([c (in-list (sort sorted-classes < #:key caar))])
+    (map cdr c)))
 
-;; ;; (listof x) ... -> (listof (listof x))
-;; (define (cartesian-product . ls)
-;;   (for ([(l i) (in-indexed ls)])
-;;     (unless (list? l)
-;;       (apply raise-argument-error 'cartesian-product "list?" i ls)))
-;;   (define (cp-2 as bs)
-;;     (for*/list ([i (in-list as)] [j (in-list bs)]) (cons i j)))
-;;   (foldr cp-2 (list (list)) ls))
+;; (listof x) ... -> (listof (listof x))
+(define (cartesian-product . ls)
+  (for ([(l i) (in-indexed ls)])
+    (unless (list? l)
+      (apply raise-argument-error 'cartesian-product "list?" i ls)))
+  (define (cp-2 as bs)
+    (for*/list ([i (in-list as)] [j (in-list bs)]) (cons i j)))
+  (foldr cp-2 (list (list)) ls))
 
-;; (define (remf f ls)
-;;   (unless (list? ls)
-;;     (raise-argument-error 'remf "list?" 1 f ls))
-;;   (unless (and (procedure? f)
-;;                (procedure-arity-includes? f 1))
-;;     (raise-argument-error 'remf "(-> any/c any/c)" 0 f ls))
-;;   (cond [(null? ls) '()]
-;;         [(f (car ls)) (cdr ls)]
-;;         [else
-;;          (cons (car ls)
-;;                (remf f (cdr ls)))]))
+(define (remf f ls)
+  (unless (list? ls)
+    (raise-argument-error 'remf "list?" 1 f ls))
+  (unless (and (procedure? f)
+               (procedure-arity-includes? f 1))
+    (raise-argument-error 'remf "(-> any/c any/c)" 0 f ls))
+  (cond [(null? ls) '()]
+        [(f (car ls)) (cdr ls)]
+        [else
+         (cons (car ls)
+               (remf f (cdr ls)))]))
 
-;; (define (remf* f ls)
-;;   (unless (list? ls)
-;;     (raise-argument-error 'remf* "list?" 1 f ls))
-;;   (unless (and (procedure? f)
-;;                (procedure-arity-includes? f 1))
-;;     (raise-argument-error 'remf* "(-> any/c any/c)" 0 f ls))
-;;   (cond [(null? ls) '()]
-;;         [(f (car ls)) (remf* f (cdr ls))]
-;;         [else
-;;          (cons (car ls)
-;;                (remf* f (cdr ls)))]))
+(define (remf* f ls)
+  (unless (list? ls)
+    (raise-argument-error 'remf* "list?" 1 f ls))
+  (unless (and (procedure? f)
+               (procedure-arity-includes? f 1))
+    (raise-argument-error 'remf* "(-> any/c any/c)" 0 f ls))
+  (cond [(null? ls) '()]
+        [(f (car ls)) (remf* f (cdr ls))]
+        [else
+         (cons (car ls)
+               (remf* f (cdr ls)))]))
 
-;; (define (index-of ls v [=? equal?])
-;;   (unless (list? ls)
-;;     (raise-argument-error 'index-of "list?" 0 ls v))
-;;   (unless (and (procedure? =?)
-;;                (procedure-arity-includes? =? 2))
-;;     (raise-argument-error 'index-of "(-> any/c any/c any/c)" 2 ls v =?))
-;;   (let loop ([ls ls]
-;;              [i 0])
-;;     (cond [(null? ls) #f]
-;;           [(=? (car ls) v) i]
-;;           [else (loop (cdr ls) (add1 i))])))
+(define (index-of ls v [=? equal?])
+  (unless (list? ls)
+    (raise-argument-error 'index-of "list?" 0 ls v))
+  (unless (and (procedure? =?)
+               (procedure-arity-includes? =? 2))
+    (raise-argument-error 'index-of "(-> any/c any/c any/c)" 2 ls v =?))
+  (let loop ([ls ls]
+             [i 0])
+    (cond [(null? ls) #f]
+          [(=? (car ls) v) i]
+          [else (loop (cdr ls) (add1 i))])))
 
-;; (define (index-where ls f)
-;;   (unless (list? ls)
-;;     (raise-argument-error 'index-where "list?" 0 ls f))
-;;   (unless (and (procedure? f)
-;;                (procedure-arity-includes? f 1))
-;;     (raise-argument-error 'index-where "(-> any/c any/c)" 1 ls f))
-;;   (let loop ([ls ls]
-;;              [i 0])
-;;     (cond [(null? ls) #f]
-;;           [(f (car ls)) i]
-;;           [else (loop (cdr ls) (add1 i))])))
+(define (index-where ls f)
+  (unless (list? ls)
+    (raise-argument-error 'index-where "list?" 0 ls f))
+  (unless (and (procedure? f)
+               (procedure-arity-includes? f 1))
+    (raise-argument-error 'index-where "(-> any/c any/c)" 1 ls f))
+  (let loop ([ls ls]
+             [i 0])
+    (cond [(null? ls) #f]
+          [(f (car ls)) i]
+          [else (loop (cdr ls) (add1 i))])))
 
-;; (define (indexes-of ls v [=? equal?])
-;;   (unless (list? ls)
-;;     (raise-argument-error 'indexes-of "list?" 0 ls v))
-;;   (unless (and (procedure? =?)
-;;                (procedure-arity-includes? =? 2))
-;;     (raise-argument-error 'indexes-of "(-> any/c any/c any/c)" 2 ls v =?))
-;;   (let loop ([ls ls]
-;;              [i 0])
-;;     (cond [(null? ls) '()]
-;;           [(=? (car ls) v) (cons i (loop (cdr ls) (add1 i)))]
-;;           [else (loop (cdr ls) (add1 i))])))
+(define (indexes-of ls v [=? equal?])
+  (unless (list? ls)
+    (raise-argument-error 'indexes-of "list?" 0 ls v))
+  (unless (and (procedure? =?)
+               (procedure-arity-includes? =? 2))
+    (raise-argument-error 'indexes-of "(-> any/c any/c any/c)" 2 ls v =?))
+  (let loop ([ls ls]
+             [i 0])
+    (cond [(null? ls) '()]
+          [(=? (car ls) v) (cons i (loop (cdr ls) (add1 i)))]
+          [else (loop (cdr ls) (add1 i))])))
 
-;; (define (indexes-where ls f)
-;;   (unless (list? ls)
-;;     (raise-argument-error 'indexes-where "list?" 0 ls f))
-;;   (unless (and (procedure? f)
-;;                (procedure-arity-includes? f 1))
-;;     (raise-argument-error 'indexes-where "(-> any/c any/c)" 1 ls f))
-;;   (let loop ([ls ls]
-;;              [i 0])
-;;     (cond [(null? ls) '()]
-;;           [(f (car ls)) (cons i (loop (cdr ls) (add1 i)))]
-;;           [else (loop (cdr ls) (add1 i))])))
+(define (indexes-where ls f)
+  (unless (list? ls)
+    (raise-argument-error 'indexes-where "list?" 0 ls f))
+  (unless (and (procedure? f)
+               (procedure-arity-includes? f 1))
+    (raise-argument-error 'indexes-where "(-> any/c any/c)" 1 ls f))
+  (let loop ([ls ls]
+             [i 0])
+    (cond [(null? ls) '()]
+          [(f (car ls)) (cons i (loop (cdr ls) (add1 i)))]
+          [else (loop (cdr ls) (add1 i))])))

--- a/tests/racket-core/testing.rkt
+++ b/tests/racket-core/testing.rkt
@@ -3,6 +3,8 @@
 (provide (all-defined-out))
 
 (define (test expected f . args)
-  (displayln (equal? expected (apply f args))))
+  (if (null? args)
+      (displayln (equal? expected f))
+      (displayln (equal? expected (apply f args)))))
 
 (define-simple-macro (err/rt-test e) e)


### PR DESCRIPTION
- to support rest of racket/list, we need:
  - with-handlers
  - optional and kw args
  - procedure-arity-includes and friends

Other edits:
- fix makeInit to return Vector instead of Array
- Numbers.add missing initial 0
- make-sequence needs extra arg for Racket >= 6.7.0.4