### PR TITLE
Various fixes and improvements

### DIFF
--- a/racketscript-compiler/racketscript/compiler/runtime/core/lib.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/lib.js
@@ -63,9 +63,9 @@ export function toString(v) {
 }
 
 export function format1(pattern, args) {
-    return pattern.replace(/{(\d+)}/g, function(match, number) { 
+    return pattern.replace(/{(\d+)}/g, function(match, number) {
 	return typeof args[number] != 'undefined'
-	    ? args[number] 
+	    ? args[number]
 	    : match;
     });
 }

--- a/racketscript-compiler/racketscript/compiler/runtime/core/ports.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/ports.js
@@ -1,73 +1,99 @@
 import {Primitive} from "./primitive.js";
 import * as $ from "./lib.js";
 
-//TODO: Quick hacked up implementation around console.log
-class Port extends Primitive {
-    constructor(read, write) {
-	super();
-	this.__state = {
-	    buffer: []
-	} ;
-	this.__read = read;
-	this.__write = write;
-    }
-
-    read(n_char) {
-	if (this.__read === undefined) {
-	    throw $.racketCoreError("Not Implemented");
-	} else {
-	    return this.__read(this.__state, n_char);
-	}
-    }
-
-    write(chars) {
-	if (this.__write === undefined) {
-	    throw $.racketCoreError("Not Implemented");
-	} else {
-	    return this.__write(this.__state, chars);
-	}
-    }
-
+class AbstractPort extends Primitive {
     isOutputPort() {
-	return this.__write && true;
+        return false;
     }
 
     isInputPort() {
-	return this.__read && true;
+        return false;
     }
 }
 
-export function makeOutputPort(write) {
-    return new Port(undefined, write);
-}
-
-export function makeInputPort(read) {
-    return new Port(read);
-}
-
-export function check(v) {
-    return (v instanceof Port);
-}
-
-export function checkInputPort(v) {
-    return check(v) && v.isInputPort();
-}
-
-export function checkOutputPort(v) {
-    return check(v) && v.isOutputPort();
-}
-
-export let standardOutputPort = makeOutputPort((state, chars) => {
-    let nl_index = chars.lastIndexOf("\n");
-    if (nl_index >= 0) {
-	let flushchars = state.buffer.join("") + chars.slice(0, nl_index);
-	let rest_chars = chars.slice(nl_index + 1);
-	state.buffer = [];
-	if (rest_chars !== "") {
-	    state.buffer.push(rest_chars);
-	}
-	console.log(flushchars);
-    } else {
-	state.buffer.push(chars);
+class AbstractOutputPort extends AbstractPort {
+    write() {
+        throw new Error(`Expected ${this.constructor.name} to implement write(chars)`)
     }
-});
+
+    isOutputPort() {
+        return true;
+    }
+}
+
+export function isPort(v) {
+    // When compiling with traceur, the `instanceof` check would fail,
+    // due to a limitation of traceur.
+    // TODO: Replace with `v instanceof AbstractPort` once this is fixed.
+    return v && (
+        v.constructor === NewlineFlushingOutputPort ||
+        v.constructor === OutputStringPort);
+}
+
+export function isInputPort(v) {
+    return isPort(v) && v.isInputPort();
+}
+
+export function isOutputPort(v) {
+    return isPort(v) && v.isOutputPort();
+}
+
+// Only writes output via the given `writeFn` when encountering a newline,
+// othewise buffers the output.
+class NewlineFlushingOutputPort extends AbstractOutputPort {
+    constructor(writeFn) {
+        super();
+        this._buffer = [];
+        this._writeFn = writeFn;
+    }
+
+    write(chars) {
+        const lastNewlineIndex = chars.lastIndexOf("\n");
+        if (lastNewlineIndex >= 0) {
+            let flushchars = this._buffer.join("") + chars.slice(0, lastNewlineIndex);
+            let restChars = chars.slice(lastNewlineIndex + 1);
+            this._buffer = [];
+            if (restChars !== "") {
+                this._buffer.push(restChars);
+            }
+            this._writeFn(flushchars);
+        } else {
+            this._buffer.push(chars);
+        }
+    }
+}
+
+export const standardOutputPort = new NewlineFlushingOutputPort((str) => console.log(str));
+export let currentOutputPort = standardOutputPort;
+
+export const standardErrorPort = new NewlineFlushingOutputPort((str) => console.log(str));
+export let currentErrorPort = standardErrorPort;
+
+
+class OutputStringPort extends AbstractOutputPort {
+    constructor() {
+        super();
+        this.__buffer = [];
+        this.__cachedString = null;
+    }
+
+    write(chars) {
+        this.__buffer.push(chars);
+        this.__cachedString = null;
+    }
+
+    getOutputString() {
+        if (this.__buffer.length > 1) {
+            this.__buffer = [this.__buffer.join('')];
+        }
+        return this.__buffer[0];
+    }
+}
+
+export function openOutputString() {
+    return new OutputStringPort();
+}
+
+export function getOutputString(outputStringPort) {
+    return outputStringPort.getOutputString();
+}

--- a/racketscript-compiler/racketscript/compiler/runtime/kernel.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/kernel.js
@@ -1,15 +1,25 @@
 import * as Core from "./core.js";
 
+/* --------------------------------------------------------------------------*/
+// String construction and manipulation
+
 export function format(pattern, ...args) {
-    //TODO: Only ~a is supported
+    //TODO: Only ~a and ~x are supported
     var matched = 0;
-    return pattern.replace(/~a/g, function(match) {
-	if (args[matched] == 'undefined') {
-	    throw Core.racketContractError("insufficient pattern arguments");
-        } else {
-            return args[matched++];
+    return pattern.replace(/~[ax]/g, function (match) {
+        if (matched >= args.length) {
+            throw Core.racketContractError("insufficient pattern arguments");
+        }
+        switch (match[1]) {
+            case 'a': return args[matched++];
+            case 'x': return args[matched++].toString(16);
         }
     });
+}
+
+
+export function listToString(lst) {
+	return Core.Pair.listToArray(lst).join('');
 }
 
 /* --------------------------------------------------------------------------*/
@@ -17,7 +27,6 @@ export function format(pattern, ...args) {
 
 export function display(v, out) {
     /* TODO: this is still line */
-    out = out || Core.Ports.standardOutputPort;
     if (v === true) {
 	out.write("#t");
     } else if (v === false) {
@@ -33,7 +42,6 @@ export function display(v, out) {
 
 export function print(v, out) {
     /* TODO: this is still line */
-    out = out || Core.Ports.standardOutputPort;
     if (v === true) {
 	out.write("#t");
     } else if (v === false) {
@@ -54,16 +62,14 @@ export function print(v, out) {
 
 export function error(...args) {
     if (args.length === 1 && Core.Symbol.check(args[0])) {
-	throw Core.racketCoreError(args[0].toString());
+        throw Core.racketCoreError(args[0].toString());
     } else if (args.length > 0 && typeof args[0] === 'string') {
-	throw Core.racketCoreError(args.map((v) => v.toString()).join(" "));
+        throw Core.racketCoreError(args.map((v) => v.toString()).join(" "));
     } else if (args.length > 0 && Core.Symbol.check(args[0])) {
-	let pattern = args.shift().toString()
-	    .concat(" ")
-	    .concat(args.shift());
-	throw Core.racketCoreError(pattern, args);
+        throw Core.racketCoreError(
+            format(`${args[0].toString()}: ${args[1]}`, ...args.slice(2)));
     } else {
-	throw Core.racketContractError("error: invalid arguments");
+        throw Core.racketContractError("error: invalid arguments");
     }
 }
 
@@ -151,7 +157,7 @@ export function sort9(lst, cmp) {
 	} else { // x = y, simulate stable sort by comparing indices
 	    return x2i.get(x) - x2i.get(y);
 	}});
- 
+
     return Core.Pair.listFromArray(srted);
 }
 

--- a/racketscript-compiler/racketscript/compiler/runtime/lib.rkt
+++ b/racketscript-compiler/racketscript/compiler/runtime/lib.rkt
@@ -173,7 +173,7 @@
 ;; ----------------------------------------------------------------------------
 ;; Errors
 
-(define default-check-message "Given: {0}, Expected: {1}, At: {2}")
+(define default-check-message "Expected: {0}, Given: {1}, At: {2}")
 
 (define-syntax-rule (type-check/raise type what)
   (unless (#js.type.check what)

--- a/tests/basic/char.rkt
+++ b/tests/basic/char.rkt
@@ -1,4 +1,37 @@
-#lang racket
+#lang racket/base
 
 (define v #\u5c)
 (displayln v)
+
+(displayln (char? #\a))
+(displayln (char? 1))
+(displayln (char? '(#\a)))
+
+; TODO: This test fails because we do not yet have a separate type for Char.
+; (displayln (char? "x"))
+
+(displayln (char<? #\a #\b))
+(displayln (char<? #\a #\a))
+(displayln (char<? #\b #\a))
+
+; This will produce the wrong result in JavaScript if the implementation
+; compares characters directly instead of looking at their codepoints.
+(displayln (char<? #\ﬆ #\𝌆))
+
+(displayln (char<=? #\a #\a))
+(displayln (char<=? #\a #\b))
+(displayln (char<=? #\b #\a))
+
+(displayln (char>? #\a #\a))
+(displayln (char>? #\a #\b))
+(displayln (char>? #\b #\a))
+
+(displayln (char>=? #\a #\a))
+(displayln (char>=? #\a #\b))
+(displayln (char>=? #\b #\a))
+
+(displayln (char=? #\a #\a))
+(displayln (char=? #\b #\a))
+
+(displayln (char->integer #\a))
+(displayln (char->integer #\☺))

--- a/tests/basic/format.rkt
+++ b/tests/basic/format.rkt
@@ -1,0 +1,8 @@
+#lang racket/base
+
+(displayln (format "~a" 1))
+(displayln (format "~a" "1"))
+(displayln (format "~a" #\b))
+(displayln (format "~x" 1))
+(displayln (format "~x" 50))
+(displayln (format "~a is ~x in hex" "15" 15))

--- a/tests/basic/port.rkt
+++ b/tests/basic/port.rkt
@@ -1,0 +1,14 @@
+#lang racket/base
+
+(define o-str-port (open-output-string))
+(displayln (port? o-str-port))
+(displayln (output-port? o-str-port))
+(display "Hello" o-str-port)
+(displayln (get-output-string o-str-port))
+(display " " o-str-port)
+(display "World" o-str-port)
+(displayln (get-output-string o-str-port))
+
+(displayln (port? (current-output-port)))
+(displayln (output-port? (current-output-port)))
+(display "Test\n" (current-output-port))

--- a/tests/basic/string.rkt
+++ b/tests/basic/string.rkt
@@ -5,3 +5,12 @@
 
 (displayln str)
 (displayln num)
+
+(displayln (string-ref str 5))
+
+(displayln (make-string 5 #\c))
+
+(displayln (list->string '(#\a #\b #\c)))
+
+(displayln (substring str 3))
+(displayln (substring str 3 7))


### PR DESCRIPTION
1. Fixes the assembler to compare to `!== false` in `if` statements.
   This fixes the behaviour of various functions such as `and`, `if`,
   and `cond` to match Racket, where `#f` is the only "falsy" value.
   **Update:** This change has been removed from this PR, see https://github.com/vishesh/racketscript/pull/73#discussion_r135356677

2. Adds support for `~x` to `format`.
3. Fixes `error` argument formatting.
4. Fixes the default contract check message.
5. Allows passing an `out` argument to `display`, `newline`, and `print`.
6. Adds basic implementations of the following functions:

   * `string-ref`
   * `make-string`
   * `list->string`
   * `char?` and `char` comparison functions
   * `char->integer`
   * `open-output-string`, `get-output-string`, and `string-port?`

This actually makes Waxeye work (the Unicode issue remains, but the other stuff seems to work).
Waxeye demo: https://glebm.github.io/waxeye/demo.html