### PR TITLE
dont run optimize tests when optimizations are off

### DIFF
--- a/tests/fixture.rkt
+++ b/tests/fixture.rkt
@@ -241,7 +241,9 @@
       (displayln "---------------------------------")
       (displayln "::: Optimizations on ::: none :::")
       (displayln "---------------------------------")
-      (run-tests tc-search-patterns)))
+      (run-tests (filter-not
+                  (λ (s) (string-contains? s "optimize"))
+                  tc-search-patterns))))
 
   ;; (displayln "")
   ;; (parameterize ([enabled-optimizations (set self-tail->loop)])

--- a/tests/optimize/tail-sum.rkt
+++ b/tests/optimize/tail-sum.rkt
@@ -8,5 +8,5 @@
 (displayln (sum 100 0))
 (displayln (sum 1000 0))
 (displayln (sum 10000 0))
-;;(displayln (sum 15000 0))
+(displayln (sum 15000 0))
 


### PR DESCRIPTION
The `tests/optimize/tail-sum.rkt` integration test is failing for me when optimizations are off.

Should the tests in `tests/optimize` be run when there are no optimizations enabled?

ps - Loving the activity in this repo.