### PR TITLE
A `make tscheck` task to typecheck the JS runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ TAGS
 *.rej
 
 *.elc
+node_modules/

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,12 @@
 ##               #
 ##               "
 
-.PHONY: build setup setup-extra clean 
+.PHONY: build setup setup-extra clean
 .PHONY: test unit-test integration-test test
 .PHONY: coverage coverage-unit-test
-.PHONY: eslint jslint
+.PHONY: eslint jslint tscheck
+
+TSC=node_modules/typescript/bin/tsc
 
 ## Compile recipes
 
@@ -61,6 +63,14 @@ jshint:
 	@echo "    RACKETSCRIPT RUNTIME LINT    "
 	@echo "++++++++++++++++++++++++++++"
 	jshint ./racketscript-compiler/racketscript/compiler/runtime/ || true
+
+# Typecheck JavaScript
+tscheck: node_modules
+	$(TSC) --noEmit --allowJs --checkJs --strict --lib es2017 --target es2017 \
+	racketscript-compiler/racketscript/compiler/runtime/kernel.js
+
+node_modules: package.json
+	npm install
 
 ## Test recipes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,11 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "typescript": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.2.tgz",
+      "integrity": "sha1-A4qV99m7tCCxvzW6MdTFwd0//jQ="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "typescript": "^2.5.2"
+  }
+}


### PR DESCRIPTION
Currently fails to run due to some issues with the type signatures but they're fixed in #96.