### PR TITLE
List improvements

### DIFF
--- a/racketscript-compiler/racketscript/compiler/runtime/core/equality.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/equality.js
@@ -37,15 +37,5 @@ export function isEqual(v1, v2) {
     // Bytes are not a Primitive.
     if (Bytes.check(v1) && Bytes.check(v2)) return Bytes.eq(v1, v2);
 
-    // TODO: We should not pass arrays to this function,
-    //   but currently we sometimes do, e.g. the empty list.
-    if (Array.isArray(v1) && Array.isArray(v2) && v1.length === v2.length) {
-        const n = a.length;
-        for (let i = 0; i < n; i++) {
-            if (!isEqual(a[i], b[i])) return false;
-        }
-        return true;
-    }
-
     return false;
 }

--- a/racketscript-compiler/racketscript/compiler/runtime/core/hash.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/hash.js
@@ -135,7 +135,7 @@ export function makeEqualFromAssocs(assocs, mutable) {
 }
 
 export function map(hash, proc) {
-    let result = Pair.Empty;
+    let result = Pair.EMPTY;
     hash._h.forEach((value, key) => {
 	result = Pair.make(proc(key, value), result)
     });

--- a/racketscript-compiler/racketscript/compiler/runtime/core/hashing.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/hashing.js
@@ -1,4 +1,4 @@
-import {hash, hashArray} from "./raw_hashing.js";
+import {hash} from "./raw_hashing.js";
 import * as Primitive from "./primitive.js";
 import * as Char from "./char.js";
 import * as Bytes from "./bytes.js";
@@ -29,12 +29,6 @@ export function hashForEqv(o) {
 export function hashForEqual(o) {
     if (Primitive.check(o)) return o.hashForEqual();
     if (Bytes.check(o)) return Bytes.hashForEqual(o);
-
-    // TODO: We should not pass arrays to this function,
-    //   but currently we sometimes do, e.g. the empty list.
-    if (Array.isArray(o)) {
-        hashArray(o, hashForEqual);
-    }
 
     return hash(o);
 }

--- a/racketscript-compiler/racketscript/compiler/runtime/core/marks.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/marks.js
@@ -4,7 +4,7 @@ import * as Symbol from "./symbol.js"
 import * as $ from "./lib.js";
 import {hashForEq as HASH} from "./hashing.js";
 
-let __frames = false;
+let __frames;
 let __prompts = new Map();
 let __async_callback_wrappers = [];
 let __defaultContinuationPromptTag
@@ -13,7 +13,7 @@ let __defaultContinuationPromptTag
 /* --------------------------------------------------------------------------*/
 
 export function init() {
-    __frames = Pair.Empty;
+    __frames = Pair.EMPTY;
     savePrompt(__defaultContinuationPromptTag);
     enterFrame();
 }

--- a/racketscript-compiler/racketscript/compiler/runtime/core/mpair.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/mpair.js
@@ -1,16 +1,16 @@
 import {Primitive} from "./primitive.js";
 import {isEqual} from "./equality.js";
 import * as $ from "./lib.js";
-import {Empty, isEmpty, isList} from "./pair.js";
+import {EMPTY, isEmpty, isList} from "./pair.js";
 
 class MPair extends Primitive {
+    /** @private */
     constructor(hd, tl) {
-	super();
-	this.hd = hd;
-	this.tl = tl;
-	this._listLength = (tl === Empty)
-	    ? 1
-	    : isList(tl) && tl._listLength + 1;
+        super();
+        this.hd = hd;
+        this.tl = tl;
+        this._listLength = isList(tl) ? tl.length + 1 : -1;
+        this._cachedHashCode = null;
     }
 
     toString() {
@@ -62,6 +62,16 @@ class MPair extends Primitive {
         }
     }
 
+    /**
+     * @return {!number}
+     */
+    hashForEqual() {
+        if (this._cachedHashCode === null) {
+            this._cachedHashCode = super.hashForEqual();
+        }
+        return this._cachedHashCode;
+    }
+
     car() {
 	return this.hd;
     }
@@ -71,20 +81,38 @@ class MPair extends Primitive {
     }
 
     setCar(v) {
-	this.hd = v;
+        if (this.hd !== v) {
+            this.hd = v;
+            this._cachedHashCode = null;
+        }
     }
 
     setCdr(v) {
-	this.tl = v;
+        if (this.tl !== v) {
+            this.tl = v;
+            this._listLength = isList(tl) ? tl.length + 1 : -1;
+            this._cachedHashCode = null;
+        }
     }
 
     get length() {
         return this._listLength;
     }
+
+    /**
+     * @return {false}
+     */
+    isImmutable() {
+        return false;
+    }
 }
 
+/**
+ * @param {*} v
+ * @return {boolean} true iff v is a non-empty list or pair.
+ */
 export function check(v) {
-    return (v instanceof MPair);
+    return typeof v === 'object' && v !== null && v.constructor === MPair;
 }
 
 export function make(hd, tl) {

--- a/racketscript-compiler/racketscript/compiler/runtime/core/struct.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/struct.js
@@ -174,7 +174,7 @@ class StructTypeDescriptor extends Primitive {
 	}
 
 	// Immutables
-	let immutables = options.immutables || [];
+	let immutables = options.immutables || Pair.EMPTY;
 	this._options.immutables = new Set(Pair.listToArray(immutables));
 	this._options.immutables.forEach((e) => {
 	    if (e < 0 || e >= options.initFieldCount) {

--- a/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
+++ b/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
@@ -154,9 +154,8 @@
 
 (define-checked+provide (car [pair pair?]) #js.pair.hd)
 (define-checked+provide (cdr [pair pair?]) #js.pair.tl)
-(define+provide cons       #js.Pair.make)
-(define+provide cons?      #js.Pair.check)
-(define+provide pair?      #js.Pair.check)
+(define+provide cons       #js.Core.Pair.make)
+(define+provide pair?      #js.Core.Pair.check)
 
 (define-checked+provide (caar [v (check/pair-of? pair? #t)])
   #js.v.hd.hd)
@@ -169,18 +168,13 @@
 (define-checked+provide (caddr [v (check/pair-of? #t (check/pair-of? #t pair?))])
   #js.v.tl.tl.hd)
 
-(define+provide null  #js.Pair.Empty)
-(define+provide list  #js.Pair.makeList)
+(define+provide null #js.Core.Pair.EMPTY)
+(define+provide list #js.Core.Pair.makeList)
 
-(define+provide null?  #js.Pair.isEmpty)
-(define+provide empty? #js.Pair.isEmpty)
-(define+provide length #js.Pair.listLength)
+(define+provide null? #js.Core.Pair.isEmpty)
+(define+provide list? #js.Core.Pair.isList)
 
-(define+provide (list? v)
-  (cond
-    [(null? v) #t]
-    [(cons? v) (list? ($> v (cdr)))]
-    [else #f]))
+(define-checked+provide (length [v list?]) #js.v.length)
 
 (define-checked+provide (reverse [lst list?])
   (let loop ([lst lst]

--- a/racketscript-compiler/racketscript/compiler/transform.rkt
+++ b/racketscript-compiler/racketscript/compiler/transform.rkt
@@ -602,7 +602,7 @@
      (ILApp (name-in-module 'core 'Pair.makeList)
             (map absyn-value->il d))]
     [(empty? d)
-     (name-in-module 'core 'Pair.Empty)]
+     (name-in-module 'core 'Pair.EMPTY)]
     [(cons? d)
      (ILApp (name-in-module 'core 'Pair.make)
             (list (absyn-value->il (car d))

--- a/tests/basic/list.rkt
+++ b/tests/basic/list.rkt
@@ -8,3 +8,17 @@
 (displayln (length (list-sq)))
 
 (equal? '(1 2 3) '(1 2 3))
+(equal? (list 1 2 3) '(1 2 3))
+
+(eq? '() null)
+(null? '())
+(list? '())
+(list? (cons 1 2))
+(list? (cons 1 '()))
+(list? (cons 1 (cons 2 '())))
+(equal? (cons 1 '()) (list 1))
+
+(pair? '())
+(pair? (cons 1 #\x))
+
+(immutable? '())


### PR DESCRIPTION
* Adds a singleton class for Empty.
* Makes `list?` O(1) instead of O(n).
* Makes `length` checked.
* Makes `immutable?` work on lists.
* Makes the `_listLength` field always a number so it's more JIT-friendly.
* Avoids the expensive `instanceof` checks in `Pair.check` and `MPair.check`.
* Adds hash code caching for `Pair` and `MPair`.
* Fixes the `listFind` predicate check.
* Minor improvements to `makeList` and `listFromArray`.
* Removes the unused `_listLength` function.
* Removes the now unnecessary Array equality and hashing from `isEqual` and `hashForEqual`.
* Removes `cons?` and `empty?` from kernel as they are not a part of the Kernel in racket.
* Adds more tests.

@vishes Hoping for a quick turnaround on this so I can proceed with extracting the rest of the mega-PR.