### PR TITLE
Reformat JS: Replace tabs with spaces

### DIFF
--- a/racketscript-compiler/racketscript/compiler/runtime/core/box.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/box.js
@@ -1,30 +1,30 @@
-import {Primitive} from "./primitive.js";
-import {isEqual} from "./equality.js";
+import { Primitive } from "./primitive.js";
+import { isEqual } from "./equality.js";
 
 class Box extends Primitive {
     constructor(v) {
-	super();
-	this.value = v;
+        super();
+        this.value = v;
     }
 
     toString() {
-	return this.value;
+        return this.value;
     }
 
     toRawString() {
-	return this.toString();
+        return this.toString();
     }
 
     equals(v) {
-	return isEqual(v.value, this.value);
+        return isEqual(v.value, this.value);
     }
 
     set(v) {
-	this.value = v;
+        this.value = v;
     }
 
     get() {
-	return this.value;
+        return this.value;
     }
 }
 

--- a/racketscript-compiler/racketscript/compiler/runtime/core/bytes.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/bytes.js
@@ -1,5 +1,5 @@
-import {Decoder as TextDecoder} from "./text_transcoder.js";
-import {hashIntArray} from "./raw_hashing.js";
+import { Decoder as TextDecoder } from "./text_transcoder.js";
+import { hashIntArray } from "./raw_hashing.js";
 
 /**
  * @param {*} bs

--- a/racketscript-compiler/racketscript/compiler/runtime/core/char.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/char.js
@@ -1,4 +1,4 @@
-import {Primitive} from "./primitive.js";
+import { Primitive } from "./primitive.js";
 
 /**
  * A single Unicode character.

--- a/racketscript-compiler/racketscript/compiler/runtime/core/check.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/check.js
@@ -2,27 +2,27 @@ export function raise(exp, ...args) {
     throw exp.apply(this, args);
 }
 
-export function truthy(val, exp, msg="") {
+export function truthy(val, exp, msg = "") {
     if (val !== true) {
-	raise(exp, msg);
+        raise(exp, msg);
     }
     return true;
 }
 
-export function falsy(val, exp, msg="") {
+export function falsy(val, exp, msg = "") {
     return truthy(val === false, exp, msg);
 }
 
-export function type(val, type, msg="") {
-    if  (val instanceof type) {
-	return true;
+export function type(val, type, msg = "") {
+    if (val instanceof type) {
+        return true;
     }
-    raise(TypeError, msg + "(" + val + " : " + typeof(val) + " != " + type.name + ")");
+    raise(TypeError, msg + "(" + val + " : " + typeof (val) + " != " + type.name + ")");
 }
 
 export function eq(val1, val2, exp, msg) {
     if (val1 !== val2) {
-	raise(exp, msg);
+        raise(exp, msg);
     }
     return true;
 }

--- a/racketscript-compiler/racketscript/compiler/runtime/core/equality.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/equality.js
@@ -37,15 +37,5 @@ export function isEqual(v1, v2) {
     // Bytes are not a Primitive.
     if (Bytes.check(v1) && Bytes.check(v2)) return Bytes.eq(v1, v2);
 
-    // TODO: We should not pass arrays to this function,
-    //   but currently we sometimes do, e.g. the empty list.
-    if (Array.isArray(v1) && Array.isArray(v2) && v1.length === v2.length) {
-        const n = a.length;
-        for (let i = 0; i < n; i++) {
-            if (!isEqual(a[i], b[i])) return false;
-        }
-        return true;
-    }
-
     return false;
 }

--- a/racketscript-compiler/racketscript/compiler/runtime/core/hash.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/hash.js
@@ -135,7 +135,7 @@ export function makeEqualFromAssocs(assocs, mutable) {
 }
 
 export function map(hash, proc) {
-    let result = Pair.Empty;
+    let result = Pair.EMPTY;
     hash._h.forEach((value, key) => {
 	result = Pair.make(proc(key, value), result)
     });

--- a/racketscript-compiler/racketscript/compiler/runtime/core/hash.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/hash.js
@@ -1,8 +1,8 @@
 import * as $ from "./lib.js";
 import * as Pair from "./pair.js";
-import {Primitive} from "./primitive.js";
-import {isEqual, isEqv, isEq} from "./equality.js";
-import {hashForEqual, hashForEqv, hashForEq} from "./hashing.js";
+import { Primitive } from "./primitive.js";
+import { isEqual, isEqv, isEq } from "./equality.js";
+import { hashForEqual, hashForEqv, hashForEq } from "./hashing.js";
 
 const hashConfigs = {
     eq: {
@@ -21,10 +21,10 @@ const hashConfigs = {
 
 class Hash extends Primitive {
     constructor(hash, type, mutable) {
-	super();
-	this._h = hash;
-	this._mutable = mutable;
-	this._type = type;
+        super();
+        this._h = hash;
+        this._mutable = mutable;
+        this._type = type;
     }
 
     toString() {
@@ -40,7 +40,7 @@ class Hash extends Primitive {
     }
 
     toRawString() {
-	return "'" + this.toString();
+        return "'" + this.toString();
     }
 
     isImmutable() {
@@ -60,44 +60,44 @@ class Hash extends Primitive {
     }
 
     set(k, v) {
-	let newH = this._h.set(k, v);
+        let newH = this._h.set(k, v);
 
-	if (this._mutable) {
-	    this._h = newH;
-	} else {
-	    return new Hash(newH, this._type, false);
-	}
+        if (this._mutable) {
+            this._h = newH;
+        } else {
+            return new Hash(newH, this._type, false);
+        }
     }
 
     size() {
-	return this._h.size;
+        return this._h.size;
     }
 
     equals(v) {
-	if (!check(v)) {
-	    return false;
-	}
+        if (!check(v)) {
+            return false;
+        }
 
-	if (this._h.size !== v._h.size || this._type !== v._type ||
-	    this._mutable !== v._mutable) {
-	    return false;
-	}
+        if (this._h.size !== v._h.size || this._type !== v._type ||
+            this._mutable !== v._mutable) {
+            return false;
+        }
 
-	for (let [key, val] of this._h) {
-        let vv = v._h.get(key);
-	    if (vv === undefined || !isEqual(val, vv)) {
-		return false;
-	    }
-	}
+        for (let [key, val] of this._h) {
+            let vv = v._h.get(key);
+            if (vv === undefined || !isEqual(val, vv)) {
+                return false;
+            }
+        }
 
-	return true;
+        return true;
     }
 }
 
 function make(items, type, mutable) {
     let h = items.reduce((acc, item) => {
-	let [k, v] = item;
-	return acc.set(k, v);
+        let [k, v] = item;
+        return acc.set(k, v);
     }, $.hamt.make(hashConfigs[type]));
     return new Hash(h, type, mutable);
 }
@@ -117,7 +117,7 @@ export function makeEqual(items, mutable) {
 function makeFromAssocs(assocs, type, mutable) {
     let items = []
     Pair.listForEach(assocs, (item) => {
-	items.push([item.hd, item.tl]);
+        items.push([item.hd, item.tl]);
     });
     return make(items, type, mutable);
 }
@@ -137,7 +137,7 @@ export function makeEqualFromAssocs(assocs, mutable) {
 export function map(hash, proc) {
     let result = Pair.EMPTY;
     hash._h.forEach((value, key) => {
-	result = Pair.make(proc(key, value), result)
+        result = Pair.make(proc(key, value), result)
     });
     return result;
 }

--- a/racketscript-compiler/racketscript/compiler/runtime/core/hashing.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/hashing.js
@@ -1,4 +1,4 @@
-import {hash, hashArray} from "./raw_hashing.js";
+import {hash} from "./raw_hashing.js";
 import * as Primitive from "./primitive.js";
 import * as Char from "./char.js";
 import * as Bytes from "./bytes.js";
@@ -29,12 +29,6 @@ export function hashForEqv(o) {
 export function hashForEqual(o) {
     if (Primitive.check(o)) return o.hashForEqual();
     if (Bytes.check(o)) return Bytes.hashForEqual(o);
-
-    // TODO: We should not pass arrays to this function,
-    //   but currently we sometimes do, e.g. the empty list.
-    if (Array.isArray(o)) {
-        hashArray(o, hashForEqual);
-    }
 
     return hash(o);
 }

--- a/racketscript-compiler/racketscript/compiler/runtime/core/hashing.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/hashing.js
@@ -1,4 +1,4 @@
-import {hash} from "./raw_hashing.js";
+import { hash } from "./raw_hashing.js";
 import * as Primitive from "./primitive.js";
 import * as Char from "./char.js";
 import * as Bytes from "./bytes.js";

--- a/racketscript-compiler/racketscript/compiler/runtime/core/keyword.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/keyword.js
@@ -1,22 +1,22 @@
-import {Primitive} from "./primitive.js";
-import {internedMake} from "./lib.js";
+import { Primitive } from "./primitive.js";
+import { internedMake } from "./lib.js";
 
 class Keyword extends Primitive {
     constructor(v) {
-	super();
-	this.v = v;
+        super();
+        this.v = v;
     }
 
     toString() {
-	return this.v;
+        return this.v;
     }
 
     toRawString() {
-	return "'" + this.v;
+        return "'" + this.v;
     }
 
     equals(v) {
-	return check(v) && this.v === v.v;
+        return check(v) && this.v === v.v;
     }
 }
 

--- a/racketscript-compiler/racketscript/compiler/runtime/core/lib.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/lib.js
@@ -1,4 +1,4 @@
-export {hamt} from "../third-party/hamt.js";
+export { hamt } from "../third-party/hamt.js";
 
 // Because we don't have a wrapper type for bytes,
 // we depend on it here for type-checking and toString conversion.
@@ -21,10 +21,10 @@ export function toString(v) {
 }
 
 export function format1(pattern, args) {
-    return pattern.toString().replace(/{(\d+)}/g, function(match, number) {
-	return typeof args[number] != 'undefined'
-	    ? args[number]
-	    : match;
+    return pattern.toString().replace(/{(\d+)}/g, function (match, number) {
+        return typeof args[number] != 'undefined'
+            ? args[number]
+            : match;
     });
 }
 
@@ -44,25 +44,25 @@ export function attachProcedureArity(fn, arity) {
 /* Errors */
 
 function makeError(name) {
-    let e = function(pattern, ...args) {
-	this.name = name;
-	this.message = format1(pattern, args);
-	this.stack = (new Error()).stack;
-	if (Error.captureStackTrace) {
+    let e = function (pattern, ...args) {
+        this.name = name;
+        this.message = format1(pattern, args);
+        this.stack = (new Error()).stack;
+        if (Error.captureStackTrace) {
             Error.captureStackTrace(this, this.constructor);
-	} else {
+        } else {
             this.stack = (new Error()).stack;
-	}
+        }
     }
     e.prototype = Object.create(Error.prototype);
     e.prototype.constructor = e;
 
     return (...args) =>
-	new (Function.prototype.bind.apply(e, [this].concat(args)))
+        new (Function.prototype.bind.apply(e, [this].concat(args)))
 }
 
-export let racketCoreError      = makeError("RacketCoreError");
-export let racketContractError  = makeError("RacketContractError");
+export let racketCoreError = makeError("RacketCoreError");
+export let racketContractError = makeError("RacketContractError");
 
 /* --------------------------------------------------------------------------*/
 /* Other Helpers */
@@ -83,20 +83,20 @@ export function argumentsSlice(a, i) {
 
 export function attachReadOnlyProperty(o, k, v) {
     return Object.defineProperty(o, k, {
-	value: v,
-	writable: false,
-	configurable: false
+        value: v,
+        writable: false,
+        configurable: false
     });
 }
 
 export function internedMake(f) {
     let cache = {};
     return (v) => {
-	if (v in cache) {
-	    return cache[v];
-	}
-	let result = f(v);
-	cache[v] = result;
-	return result;
+        if (v in cache) {
+            return cache[v];
+        }
+        let result = f(v);
+        cache[v] = result;
+        return result;
     }
 }

--- a/racketscript-compiler/racketscript/compiler/runtime/core/marks.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/marks.js
@@ -4,7 +4,7 @@ import * as Symbol from "./symbol.js"
 import * as $ from "./lib.js";
 import {hashForEq as HASH} from "./hashing.js";
 
-let __frames = false;
+let __frames;
 let __prompts = new Map();
 let __async_callback_wrappers = [];
 let __defaultContinuationPromptTag
@@ -13,7 +13,7 @@ let __defaultContinuationPromptTag
 /* --------------------------------------------------------------------------*/
 
 export function init() {
-    __frames = Pair.Empty;
+    __frames = Pair.EMPTY;
     savePrompt(__defaultContinuationPromptTag);
     enterFrame();
 }

--- a/racketscript-compiler/racketscript/compiler/runtime/core/marks.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/marks.js
@@ -2,7 +2,7 @@
 import * as Pair from "./pair.js"
 import * as Symbol from "./symbol.js"
 import * as $ from "./lib.js";
-import {hashForEq as HASH} from "./hashing.js";
+import { hashForEq as HASH } from "./hashing.js";
 
 let __frames;
 let __prompts = new Map();
@@ -59,8 +59,8 @@ AbortCurrentContinuation.prototype.constructor = AbortCurrentContinuation;
 function savePrompt(promptTag) {
     let promptVal = __prompts.get(promptTag);
     if (promptVal === undefined) {
-	promptVal = []
-	__prompts.set(promptTag, promptVal);
+        promptVal = []
+        __prompts.set(promptTag, promptVal);
     }
     // Most recent prompt is at the end of array.
     promptVal.push(__frames.hd)
@@ -69,21 +69,21 @@ function savePrompt(promptTag) {
 function deleteCurrentPrompt(promptTag) {
     let promptVal = __prompts.get(promptTag);
     if (promptVal === undefined) {
-	throw $.racketCoreError("No corresponding tag in continuation!");
+        throw $.racketCoreError("No corresponding tag in continuation!");
     }
     promptVal.pop()
     if (promptVal.length === 0) {
-	__prompts.delete(promptTag);
+        __prompts.delete(promptTag);
     }
 }
 
 function getPromptFrame(promptTag) {
     if (promptTag === undefined) {
-	return promptTag;
+        return promptTag;
     } else {
-	let result = __prompts.get(promptTag);
-	return (result && result[result.length-1])
-	    || undefined;
+        let result = __prompts.get(promptTag);
+        return (result && result[result.length - 1])
+            || undefined;
     }
 }
 
@@ -98,17 +98,17 @@ export function isContinuationPromptTag(tag) {
 export function callWithContinuationPrompt(proc, promptTag, handler, ...args) {
     promptTag = promptTag || __defaultContinuationPromptTag;
     try {
-	savePrompt(promptTag);
-	return proc.apply(null, args);
+        savePrompt(promptTag);
+        return proc.apply(null, args);
     } catch (e) {
-	if (e instanceof AbortCurrentContinuation &&
-	    e.promptTag === promptTag) {
-	    return handler.apply(null, e.handlerArgs);
-	} else {
-	    throw e;
-	}
+        if (e instanceof AbortCurrentContinuation &&
+            e.promptTag === promptTag) {
+            return handler.apply(null, e.handlerArgs);
+        } else {
+            throw e;
+        }
     } finally {
-	deleteCurrentPrompt(promptTag);
+        deleteCurrentPrompt(promptTag);
     }
 }
 
@@ -120,7 +120,7 @@ export function getFrames() {
 
 export function updateFrame(newFrames, oldFrames) {
     if (__frames !== oldFrames) {
-	throw new Error("current frame doesn't match with old frame");
+        throw new Error("current frame doesn't match with old frame");
     }
     return __frames = newFrames;
 }
@@ -140,17 +140,17 @@ export function getContinuationMarks(promptTag) {
     let frames = __frames;
     let promptFrame = getPromptFrame(promptTag);
     if (promptFrame === undefined &&
-	promptTag !== __defaultContinuationPromptTag) {
-	throw $.racketCoreError("No corresponding tag in continuation!");
+        promptTag !== __defaultContinuationPromptTag) {
+        throw $.racketCoreError("No corresponding tag in continuation!");
     }
 
     let result = [];
     while (!Pair.isEmpty(frames)) {
-	if (frames.hd === promptFrame) {
-	    break;
-	}
-	result.push(frames.hd);
-	frames = frames.tl;
+        if (frames.hd === promptFrame) {
+            break;
+        }
+        result.push(frames.hd);
+        frames = frames.tl;
     }
     return result;
 }
@@ -162,14 +162,14 @@ export function getMarks(framesArr, key, promptTag) {
 
     let result = []
     for (let ii = 0; ii < framesArr.length; ++ii) {
-	//FIXME: for-of requires polyfill
-	let fr = framesArr[ii];
-	if (keyHash in fr) {
-	    if (fr === promptFrame) {
-		break;
-	    }
-	    result.push(fr[keyHash]);
-	}
+        //FIXME: for-of requires polyfill
+        let fr = framesArr[ii];
+        if (keyHash in fr) {
+            if (fr === promptFrame) {
+                break;
+            }
+            result.push(fr[keyHash]);
+        }
     }
     return Pair.listFromArray(result);
 }
@@ -179,25 +179,25 @@ export function getMarks(framesArr, key, promptTag) {
 export function getFirstMark(frames, key, noneV) {
     let keyHash = HASH(key);
     return Pair.listFind(frames, (fr) => {
-	if (keyHash in fr) {
-	    return fr[keyHash];
-	}
+        if (keyHash in fr) {
+            return fr[keyHash];
+        }
     }) || noneV;
 }
 
 export function wrapWithContext(fn) {
     return (function (currentFrames) {
-	let state = {};
-	__async_callback_wrappers.forEach((w) => w.onCreate(state));
-	return function (...args) {
-	    init();
-	    __async_callback_wrappers.forEach((w) => w.onInvoke(state));
-	    try {
-		return fn.apply(null, args);
-	    } finally {
-		/* This callback/coroutine is finished */
-		__frames = undefined;
-	    }
-	}
+        let state = {};
+        __async_callback_wrappers.forEach((w) => w.onCreate(state));
+        return function (...args) {
+            init();
+            __async_callback_wrappers.forEach((w) => w.onInvoke(state));
+            try {
+                return fn.apply(null, args);
+            } finally {
+                /* This callback/coroutine is finished */
+                __frames = undefined;
+            }
+        }
     })(__frames);
 }

--- a/racketscript-compiler/racketscript/compiler/runtime/core/mpair.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/mpair.js
@@ -1,16 +1,16 @@
 import {Primitive} from "./primitive.js";
 import {isEqual} from "./equality.js";
 import * as $ from "./lib.js";
-import {Empty, isEmpty, isList} from "./pair.js";
+import {EMPTY, isEmpty, isList} from "./pair.js";
 
 class MPair extends Primitive {
+    /** @private */
     constructor(hd, tl) {
-	super();
-	this.hd = hd;
-	this.tl = tl;
-	this._listLength = (tl === Empty)
-	    ? 1
-	    : isList(tl) && tl._listLength + 1;
+        super();
+        this.hd = hd;
+        this.tl = tl;
+        this._listLength = isList(tl) ? tl.length + 1 : -1;
+        this._cachedHashCode = null;
     }
 
     toString() {
@@ -62,6 +62,16 @@ class MPair extends Primitive {
         }
     }
 
+    /**
+     * @return {!number}
+     */
+    hashForEqual() {
+        if (this._cachedHashCode === null) {
+            this._cachedHashCode = super.hashForEqual();
+        }
+        return this._cachedHashCode;
+    }
+
     car() {
 	return this.hd;
     }
@@ -71,20 +81,38 @@ class MPair extends Primitive {
     }
 
     setCar(v) {
-	this.hd = v;
+        if (this.hd !== v) {
+            this.hd = v;
+            this._cachedHashCode = null;
+        }
     }
 
     setCdr(v) {
-	this.tl = v;
+        if (this.tl !== v) {
+            this.tl = v;
+            this._listLength = isList(tl) ? tl.length + 1 : -1;
+            this._cachedHashCode = null;
+        }
     }
 
     get length() {
         return this._listLength;
     }
+
+    /**
+     * @return {false}
+     */
+    isImmutable() {
+        return false;
+    }
 }
 
+/**
+ * @param {*} v
+ * @return {boolean} true iff v is a non-empty list or pair.
+ */
 export function check(v) {
-    return (v instanceof MPair);
+    return typeof v === 'object' && v !== null && v.constructor === MPair;
 }
 
 export function make(hd, tl) {

--- a/racketscript-compiler/racketscript/compiler/runtime/core/mpair.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/mpair.js
@@ -1,7 +1,7 @@
-import {Primitive} from "./primitive.js";
-import {isEqual} from "./equality.js";
+import { Primitive } from "./primitive.js";
+import { isEqual } from "./equality.js";
 import * as $ from "./lib.js";
-import {EMPTY, isEmpty, isList} from "./pair.js";
+import { EMPTY, isEmpty, isList } from "./pair.js";
 
 class MPair extends Primitive {
     /** @private */
@@ -35,7 +35,7 @@ class MPair extends Primitive {
     }
 
     toRawString() {
-	return "'" + this.toString();
+        return "'" + this.toString();
     }
 
     equals(v) {
@@ -73,11 +73,11 @@ class MPair extends Primitive {
     }
 
     car() {
-	return this.hd;
+        return this.hd;
     }
 
     cdr() {
-	return this.tl;
+        return this.tl;
     }
 
     setCar(v) {

--- a/racketscript-compiler/racketscript/compiler/runtime/core/numbers.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/numbers.js
@@ -3,38 +3,38 @@ import * as $ from "./lib.js";
 /* Arithmetic */
 
 export function add(...operands) {
-    return [].reduce.call(operands, function(a, b) {
-	return a + b
+    return [].reduce.call(operands, function (a, b) {
+        return a + b
     }, 0);
 }
 
 export function sub(...operands) {
     if (operands.length === 1) {
-	return -operands[0];
+        return -operands[0];
     } else {
-	let result = operands[0];
-	for (var i = 1; i < operands.length; ++i) {
-	    result -= operands[i];
-	}
-	return result;
+        let result = operands[0];
+        for (var i = 1; i < operands.length; ++i) {
+            result -= operands[i];
+        }
+        return result;
     }
 }
 
 export function mul(...operands) {
-    return [].reduce.call(operands, function(a, b) {
-	return a * b
+    return [].reduce.call(operands, function (a, b) {
+        return a * b
     }, 1);
 }
 
 export function div(...operands) {
     if (operands.length === 1) {
-	return 1 / operands[0];
+        return 1 / operands[0];
     } else {
-	var result = operands[0];
-	for (var i = 1; i < operands.length; ++i) {
-	    result /= operands[i];
-	}
-	return result;
+        var result = operands[0];
+        for (var i = 1; i < operands.length; ++i) {
+            result /= operands[i];
+        }
+        return result;
     }
 }
 
@@ -42,35 +42,35 @@ export function div(...operands) {
 
 export function compare(cmp, operands) {
     if (operands.length < 2) {
-	throw $.racketCoreError("compare {0}",
-				    "atleast 2 arguments required");
+        throw $.racketCoreError("compare {0}",
+            "atleast 2 arguments required");
     }
     for (var i = 1; i < operands.length; i++) {
-	if (!cmp(operands[i - 1], operands[i])) {
-	    return false;
-	}
+        if (!cmp(operands[i - 1], operands[i])) {
+            return false;
+        }
     }
     return true;
 }
 
 export function lt(...operands) {
-    return compare(function(a, b) { return a < b }, operands)
+    return compare(function (a, b) { return a < b }, operands)
 }
 
 export function lte(...operands) {
-    return compare(function(a, b) { return a <= b }, operands)
+    return compare(function (a, b) { return a <= b }, operands)
 }
 
 export function gt(...operands) {
-    return compare(function(a, b) { return a > b }, operands)
+    return compare(function (a, b) { return a > b }, operands)
 }
 
 export function gte(...operands) {
-    return compare(function(a, b) { return a >= b }, operands)
+    return compare(function (a, b) { return a >= b }, operands)
 }
 
 export function equals(...operands) {
-    return compare(function(a, b) { return a === b }, operands)
+    return compare(function (a, b) { return a === b }, operands)
 }
 
 export function check(v) {

--- a/racketscript-compiler/racketscript/compiler/runtime/core/pair.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/pair.js
@@ -1,5 +1,5 @@
-import {Primitive} from "./primitive.js";
-import {isEqual} from "./equality.js";
+import { Primitive } from "./primitive.js";
+import { isEqual } from "./equality.js";
 import * as $ from "./lib.js";
 
 /** @singleton */
@@ -64,7 +64,7 @@ export class Pair extends Primitive {
     }
 
     toRawString() {
-	return "'" + this.toString();
+        return "'" + this.toString();
     }
 
     equals(v) {

--- a/racketscript-compiler/racketscript/compiler/runtime/core/ports.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/ports.js
@@ -1,4 +1,4 @@
-import {Primitive} from "./primitive.js";
+import { Primitive } from "./primitive.js";
 import * as $ from "./lib.js";
 import * as UString from "./unicode_string.js";
 

--- a/racketscript-compiler/racketscript/compiler/runtime/core/primitive.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/primitive.js
@@ -1,5 +1,5 @@
 import * as $ from "./lib.js";
-import {hashString} from "./raw_hashing.js";
+import { hashString } from "./raw_hashing.js";
 
 /**
  * Base class for various compound data types

--- a/racketscript-compiler/racketscript/compiler/runtime/core/struct.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/struct.js
@@ -1,8 +1,8 @@
 import * as C from "./check.js";
 import * as $ from "./lib.js";
 import * as Pair from "./pair.js";
-import {Primitive} from "./primitive.js";
-import {isEqual} from "./equality.js";
+import { Primitive } from "./primitive.js";
+import { isEqual } from "./equality.js";
 import * as Values from "./values.js";
 
 // This module implements Racket structs via three classes which
@@ -33,109 +33,109 @@ import * as Values from "./values.js";
 // - Prefab
 
 class Struct extends Primitive {
-    constructor(desc, fields, callerName=false) {
-	super();
-	this._desc = desc; /* struct-type-descriptor */
+    constructor(desc, fields, callerName = false) {
+        super();
+        this._desc = desc; /* struct-type-descriptor */
 
-	C.eq(fields.length,
-	     this._desc._totalInitFields,
-	     $.racketCoreError,
-	     "arity mismatch");
+        C.eq(fields.length,
+            this._desc._totalInitFields,
+            $.racketCoreError,
+            "arity mismatch");
 
-	// Guard's are applied starting from subtype to supertype
-	// Later when we instantiate the subtype, its guard will be
-	// called in its constructor, hence maintaining the required
-	// order
-	let guardLambda = this._desc._options.guard;
-	let finalCallerName = callerName ||
-	    this._desc._options.constructorName ||
-	    this._desc._options.name;
-	if (guardLambda) {
-	    let guardFields = fields.concat(finalCallerName);
-	    fields = guardLambda.apply(null, guardFields).getAll()
-	}
+        // Guard's are applied starting from subtype to supertype
+        // Later when we instantiate the subtype, its guard will be
+        // called in its constructor, hence maintaining the required
+        // order
+        let guardLambda = this._desc._options.guard;
+        let finalCallerName = callerName ||
+            this._desc._options.constructorName ||
+            this._desc._options.name;
+        if (guardLambda) {
+            let guardFields = fields.concat(finalCallerName);
+            fields = guardLambda.apply(null, guardFields).getAll()
+        }
 
-	// Initialize current and super instance
-	this._superStructInstance = false /* Struct instance of super-type */
-	let superType = this._desc.getSuperType();
-	if (superType !== false) {
-	    let superInitFields = fields.slice(0, superType._totalInitFields);
-	    this._fields = fields.slice(superType._totalInitFields);
-	    this._superStructInstance = superType
-		.getStructConstructor(finalCallerName)
-		.apply(null, superInitFields);
-	} else {
-	    this._fields = fields;
-	}
+        // Initialize current and super instance
+        this._superStructInstance = false /* Struct instance of super-type */
+        let superType = this._desc.getSuperType();
+        if (superType !== false) {
+            let superInitFields = fields.slice(0, superType._totalInitFields);
+            this._fields = fields.slice(superType._totalInitFields);
+            this._superStructInstance = superType
+                .getStructConstructor(finalCallerName)
+                .apply(null, superInitFields);
+        } else {
+            this._fields = fields;
+        }
 
-	// Auto fields
-	let autoV = this._desc._options.autoV; /* Initial value for auto fields */
-	for (let i = 0; i < this._desc._options.autoFieldCount; i++) {
-	    this._fields.push(autoV);
-	}
+        // Auto fields
+        let autoV = this._desc._options.autoV; /* Initial value for auto fields */
+        for (let i = 0; i < this._desc._options.autoFieldCount; i++) {
+            this._fields.push(autoV);
+        }
     }
 
     toString() {
-	let fields = "";
-	for (let i = 0; i < this._fields.length; i++) {
-	    fields += this._fields[i].toString();
-	    if (i !== this._fields.length - 1) {
-		fields += " ";
-	    }
-	}
-	return "#(struct:" + this._desc.getName() + " " + fields + ")";
+        let fields = "";
+        for (let i = 0; i < this._fields.length; i++) {
+            fields += this._fields[i].toString();
+            if (i !== this._fields.length - 1) {
+                fields += " ";
+            }
+        }
+        return "#(struct:" + this._desc.getName() + " " + fields + ")";
     }
 
     toRawString() {
-	return this.toString();
+        return this.toString();
     }
 
     equals(v) {
-	if (!check(v, this._desc)) {
-	    return false;
-	}
+        if (!check(v, this._desc)) {
+            return false;
+        }
 
-	// TODO: Support equal+hash property
+        // TODO: Support equal+hash property
 
-	if (this._desc._options.inspector) {
-	    // Not a transparent inspector
-	    return this === v;
-	}
+        if (this._desc._options.inspector) {
+            // Not a transparent inspector
+            return this === v;
+        }
 
-	for (let i = 0; i < this._fields.length; i++) {
-	    if (!isEqual(this._fields[i], v._fields[i])) {
-		return false;
-	    }
-	}
+        for (let i = 0; i < this._fields.length; i++) {
+            if (!isEqual(this._fields[i], v._fields[i])) {
+                return false;
+            }
+        }
 
-	return true;
+        return true;
     }
 
     getField(n) {
-	if (n >= this._fields.length) {
-	    throw new Error("TypeError: invalid field at position " + n);
-	}
-	return this._fields[n];
+        if (n >= this._fields.length) {
+            throw new Error("TypeError: invalid field at position " + n);
+        }
+        return this._fields[n];
     }
 
     setField(n, v) {
-	C.truthy(n < this._fields.length, $.racketCoreError,
-		 "invalid field at position");
-	C.falsy(this._desc.isFieldImmutable(n), $.racketCoreError,
-		 "field is immutable");
-	this._fields[n] = v;
+        C.truthy(n < this._fields.length, $.racketCoreError,
+            "invalid field at position");
+        C.falsy(this._desc.isFieldImmutable(n), $.racketCoreError,
+            "field is immutable");
+        this._fields[n] = v;
     }
 
     // Return false if targetDesc is not a superType of current struct
     // or return struct instance of struct-type-descriptor targetDesc
     _maybeFindSuperInstance(targetDesc) {
-	for (let s = this; s !== false; s = s._superStructInstance) {
-	    if (s._desc === targetDesc) {
-		return s;
-	    }
-	}
+        for (let s = this; s !== false; s = s._superStructInstance) {
+            if (s._desc === targetDesc) {
+                return s;
+            }
+        }
 
-	return false;
+        return false;
     }
 }
 
@@ -143,166 +143,166 @@ class Struct extends Primitive {
 
 class StructTypeDescriptor extends Primitive {
     constructor(options) {
-	super();
-	// Visit makeStructType (or make-struct-type in Racket docs)
-	// to see the structure of options
-	this._options = options;
+        super();
+        // Visit makeStructType (or make-struct-type in Racket docs)
+        // to see the structure of options
+        this._options = options;
 
-	// Initialize properties
-	// supers in struct-type-property are also added when
-	// attached. However propeties attached to super types of this
-	// struct are not added here and will have to be followed.
-	let props = options.props && Pair.listToArray(options.props);
-	this._options.props = new Map();
-	if (props) {
-	    // TODO: If prop is already added, then check associated
-	    // values with eq?, else raise contract-errorx
-	    for (let prop of props) {
-		prop.hd.attachToStructTypeDescriptor(this, prop.tl)
-	    }
-	}
-	this._propProcedure = this._findProperty(propProcedure);
+        // Initialize properties
+        // supers in struct-type-property are also added when
+        // attached. However propeties attached to super types of this
+        // struct are not added here and will have to be followed.
+        let props = options.props && Pair.listToArray(options.props);
+        this._options.props = new Map();
+        if (props) {
+            // TODO: If prop is already added, then check associated
+            // values with eq?, else raise contract-errorx
+            for (let prop of props) {
+                prop.hd.attachToStructTypeDescriptor(this, prop.tl)
+            }
+        }
+        this._propProcedure = this._findProperty(propProcedure);
 
-	// Value for auto fields
-	this._options.autoV = this._options.autoV || false;
+        // Value for auto fields
+        this._options.autoV = this._options.autoV || false;
 
-	// Number of intializing fields needed, that is including
-	// those of super types
-	this._totalInitFields = options.initFieldCount;
-	if (options.superType) {
-	    this._totalInitFields += options.superType._totalInitFields;
-	}
+        // Number of intializing fields needed, that is including
+        // those of super types
+        this._totalInitFields = options.initFieldCount;
+        if (options.superType) {
+            this._totalInitFields += options.superType._totalInitFields;
+        }
 
-	// Immutables
-	let immutables = options.immutables || Pair.EMPTY;
-	this._options.immutables = new Set(Pair.listToArray(immutables));
-	this._options.immutables.forEach((e) => {
-	    if (e < 0 || e >= options.initFieldCount) {
-		C.raise("invalid index in immutables provided");
-	    }
-	});
+        // Immutables
+        let immutables = options.immutables || Pair.EMPTY;
+        this._options.immutables = new Set(Pair.listToArray(immutables));
+        this._options.immutables.forEach((e) => {
+            if (e < 0 || e >= options.initFieldCount) {
+                C.raise("invalid index in immutables provided");
+            }
+        });
     }
 
     static make(options) {
-	return Object.freeze(new StructTypeDescriptor(options));
+        return Object.freeze(new StructTypeDescriptor(options));
     }
 
     toString() {
-	return "#<struct-type:" + this._options.name + ">";
+        return "#<struct-type:" + this._options.name + ">";
     }
 
     toRawString() {
-	return this.toString();
+        return this.toString();
     }
 
     getName() {
-	return this._options.name;
+        return this._options.name;
     }
 
     getSuperType() {
-	return this._options.superType;
+        return this._options.superType;
     }
 
     getApplicableStructObject(structObject, procSpec) {
-	let structfn = function (...args) {
-	    // Struct object is also a procedure
-	    let proc;
-	    if (typeof(procSpec) === 'function') {
-		proc = procSpec;
-		// Structure object is sent only when procSpec is
-		// function, not when we get procedure from field.
-		args.unshift(structObject);
-	    } else if (Number.isInteger(procSpec)) {
-		proc = structObject.getField(procSpec);
-	    } else {
-		throw new Error("ValueError: invalid field at position "
-				+ procSpec);
-	    }
-	    return proc.apply(null, args);
-	}
-	structfn.__rjs_struct_object = structObject;
-	return structfn;
+        let structfn = function (...args) {
+            // Struct object is also a procedure
+            let proc;
+            if (typeof (procSpec) === 'function') {
+                proc = procSpec;
+                // Structure object is sent only when procSpec is
+                // function, not when we get procedure from field.
+                args.unshift(structObject);
+            } else if (Number.isInteger(procSpec)) {
+                proc = structObject.getField(procSpec);
+            } else {
+                throw new Error("ValueError: invalid field at position "
+                    + procSpec);
+            }
+            return proc.apply(null, args);
+        }
+        structfn.__rjs_struct_object = structObject;
+        return structfn;
     }
 
     maybeStructObject(s) {
-	let structObject;
-	if (s instanceof Struct) {
-	    return s;
-	} else if (s instanceof Function &&
-		   (s.__rjs_struct_object instanceof Struct)) {
-	    return s.__rjs_struct_object;
-	} else {
-	    return false;
-	}
+        let structObject;
+        if (s instanceof Struct) {
+            return s;
+        } else if (s instanceof Function &&
+            (s.__rjs_struct_object instanceof Struct)) {
+            return s.__rjs_struct_object;
+        } else {
+            return false;
+        }
     }
 
-    getStructConstructor(subtype=false) {
-	// subtype: Name of subtype which is used to call the constructor
-	//   returned here.
-	return $.attachReadOnlyProperty((...args) => {
-	    let structObject = new Struct(this, args, subtype);
-	    let hasPropProc = this._propProcedure !== undefined &&
-		this._propProcedure !== false;
-	    let hasProcSpec = this._options.procSpec !== undefined &&
-		this._options.procSpec !== false;
+    getStructConstructor(subtype = false) {
+        // subtype: Name of subtype which is used to call the constructor
+        //   returned here.
+        return $.attachReadOnlyProperty((...args) => {
+            let structObject = new Struct(this, args, subtype);
+            let hasPropProc = this._propProcedure !== undefined &&
+                this._propProcedure !== false;
+            let hasProcSpec = this._options.procSpec !== undefined &&
+                this._options.procSpec !== false;
 
-	    if (!hasPropProc && !hasProcSpec) {
-		return structObject;
-	    } else if (hasPropProc) {
-		return this.getApplicableStructObject(
-		    structObject,
-		    this._propProcedure);
-	    } else {
-		return this.getApplicableStructObject(
-		    structObject,
-		    this._options.procSpec);
-	    }
-	}, "racketProcedureType", "struct-constructor");
+            if (!hasPropProc && !hasProcSpec) {
+                return structObject;
+            } else if (hasPropProc) {
+                return this.getApplicableStructObject(
+                    structObject,
+                    this._propProcedure);
+            } else {
+                return this.getApplicableStructObject(
+                    structObject,
+                    this._options.procSpec);
+            }
+        }, "racketProcedureType", "struct-constructor");
     }
 
     getStructPredicate() {
-	return $.attachReadOnlyProperty((s) => {
-	    let structObject = this.maybeStructObject(s);
-	    return structObject &&
-		structObject._maybeFindSuperInstance(this) && true;
-	}, "racketProcedureType", "struct-predicate");
+        return $.attachReadOnlyProperty((s) => {
+            let structObject = this.maybeStructObject(s);
+            return structObject &&
+                structObject._maybeFindSuperInstance(this) && true;
+        }, "racketProcedureType", "struct-predicate");
     }
 
     getStructAccessor() {
-	return $.attachReadOnlyProperty((s, pos) => {
-	    let structObject = this.maybeStructObject(s);
-	    if (!structObject) {
-		C.raise(TypeError,
-			"(" + s + " : " + typeof(s) + " != " +
-			this._options.name + " object)");
-	    }
+        return $.attachReadOnlyProperty((s, pos) => {
+            let structObject = this.maybeStructObject(s);
+            if (!structObject) {
+                C.raise(TypeError,
+                    "(" + s + " : " + typeof (s) + " != " +
+                    this._options.name + " object)");
+            }
 
-	    let sobj = structObject._maybeFindSuperInstance(this);
-	    if (sobj === false) {
-		C.raise($.racketCoreError, "accessor applied to invalid type")
-	    }
+            let sobj = structObject._maybeFindSuperInstance(this);
+            if (sobj === false) {
+                C.raise($.racketCoreError, "accessor applied to invalid type")
+            }
 
-	    return sobj.getField(pos);
-	}, "racketProcedureType", "struct-accessor");
+            return sobj.getField(pos);
+        }, "racketProcedureType", "struct-accessor");
     }
 
     getStructMutator() {
-	return $.attachReadOnlyProperty((s, pos, v) => {
-	    let structObject = this.maybeStructObject(s);
-	    if (!structObject) {
-		C.raise(TypeError,
-			"(" + s + " : " + typeof(s) + " != " +
-			this._options.name + " object)");
-	    }
+        return $.attachReadOnlyProperty((s, pos, v) => {
+            let structObject = this.maybeStructObject(s);
+            if (!structObject) {
+                C.raise(TypeError,
+                    "(" + s + " : " + typeof (s) + " != " +
+                    this._options.name + " object)");
+            }
 
-	    let sobj = structObject._maybeFindSuperInstance(this);
-	    if (sobj === false) {
-		C.raise($.racketCoreError, "mutator applied to invalid type")
-	    }
+            let sobj = structObject._maybeFindSuperInstance(this);
+            if (sobj === false) {
+                C.raise($.racketCoreError, "mutator applied to invalid type")
+            }
 
-	    return sobj.setField(pos, v);
+            return sobj.setField(pos, v);
 
-	}, "racketProcedureType", "struct-mutator");
+        }, "racketProcedureType", "struct-mutator");
     }
 
     // Find value associated with property `prop` or return `undefined`
@@ -316,18 +316,18 @@ class StructTypeDescriptor extends Primitive {
     // The first and third case can be handled together. See property
     // initialization in constructor.
     _findProperty(prop) {
-	for (let desc = this; desc; desc = desc.getSuperType()) {
-	    let val = desc._options.props.get(prop);
-	    if (val !== undefined) {
-		return val;
-	    }
-	}
+        for (let desc = this; desc; desc = desc.getSuperType()) {
+            let val = desc._options.props.get(prop);
+            if (val !== undefined) {
+                return val;
+            }
+        }
 
-	return undefined;
+        return undefined;
     }
 
     isFieldImmutable(n) {
-	return this._options.immutables.has(n);
+        return this._options.immutables.has(n);
     }
 }
 
@@ -335,53 +335,53 @@ class StructTypeDescriptor extends Primitive {
 
 class StructTypeProperty extends Primitive {
     constructor(args) {
-	super();
+        super();
 
-	this._name =  args.name.toString();
-	this._guard = args.guard || false; /* applied when attaching */
-	this._canImpersonate = args.canImpersonate || false; /* TODO */
-	this._supers = (args.supers && Pair.listToArray(args.supers)) || [];
+        this._name = args.name.toString();
+        this._guard = args.guard || false; /* applied when attaching */
+        this._canImpersonate = args.canImpersonate || false; /* TODO */
+        this._supers = (args.supers && Pair.listToArray(args.supers)) || [];
     }
 
     static make(args) {
-	return Object.freeze(new StructTypeProperty(args));
+        return Object.freeze(new StructTypeProperty(args));
     }
 
     toString() {
-	return "#<struct-type-property:" + this._name + ">";
+        return "#<struct-type-property:" + this._name + ">";
     }
 
     toRawString() {
-	return this.toString();
+        return this.toString();
     }
 
     getPropertyPredicate() {
-	return (v) => {
-	    if (v instanceof StructTypeDescriptor) {
-		var desc = v;
-	    } else if (v instanceof Struct) {
-		var desc = v._desc;
-	    } else {
-		return false;
-	    }
+        return (v) => {
+            if (v instanceof StructTypeDescriptor) {
+                var desc = v;
+            } else if (v instanceof Struct) {
+                var desc = v._desc;
+            } else {
+                return false;
+            }
 
-	    return desc._findProperty(this) !== undefined;
-	}
+            return desc._findProperty(this) !== undefined;
+        }
     }
 
     getPropertyAccessor() {
-	return (v) => { /* property acccessor */
-	    if (v instanceof StructTypeDescriptor) {
-		var desc = v;
-	    } else if (v instanceof Struct) {
-		var desc = v._desc;
-	    } else {
-		C.raise($.racketCoreError, "invalid argument to accessor");
-	    }
+        return (v) => { /* property acccessor */
+            if (v instanceof StructTypeDescriptor) {
+                var desc = v;
+            } else if (v instanceof Struct) {
+                var desc = v._desc;
+            } else {
+                C.raise($.racketCoreError, "invalid argument to accessor");
+            }
 
-	    return desc._findProperty(this) ||
-		C.raise($.racketCoreError, "property not in struct");
-	}
+            return desc._findProperty(this) ||
+                C.raise($.racketCoreError, "property not in struct");
+        }
     }
 
     // Attaches current property with given struct descriptor
@@ -391,16 +391,16 @@ class StructTypeProperty extends Primitive {
     // Lambda associated with each item in supers of this
     // property is called with the result of guard application
     attachToStructTypeDescriptor(desc, v) {
-	let newV = v;
-	if (this._guard) {
-	    newV = this._guard(v, Pair.listFromArray(structTypeInfo(desc)));
-	}
-	desc._options.props.set(this, newV);
-	this._supers.forEach((superEntry) => {
-	    let prop = superEntry.hd;
-	    let proc = superEntry.tl;
-	    prop.attachToStructTypeDescriptor(desc, proc(newV));
-	});
+        let newV = v;
+        if (this._guard) {
+            newV = this._guard(v, Pair.listFromArray(structTypeInfo(desc)));
+        }
+        desc._options.props.set(this, newV);
+        this._supers.forEach((superEntry) => {
+            let prop = superEntry.hd;
+            let proc = superEntry.tl;
+            prop.attachToStructTypeDescriptor(desc, proc(newV));
+        });
     }
 }
 
@@ -410,9 +410,9 @@ export function makeStructTypeProperty(options) {
     let stProp = StructTypeProperty.make(options);
 
     return Values.make([
-	stProp,
-	stProp.getPropertyPredicate(),
-	stProp.getPropertyAccessor()
+        stProp,
+        stProp.getPropertyPredicate(),
+        stProp.getPropertyAccessor()
     ]);
 }
 
@@ -421,11 +421,11 @@ export function makeStructTypeProperty(options) {
 export function makeStructType(options) {
     let descriptor = new StructTypeDescriptor(options);
     return Values.make([
-	descriptor,
-	descriptor.getStructConstructor(),
-	descriptor.getStructPredicate(),
-	descriptor.getStructAccessor(),
-	descriptor.getStructMutator()
+        descriptor,
+        descriptor.getStructConstructor(),
+        descriptor.getStructPredicate(),
+        descriptor.getStructAccessor(),
+        descriptor.getStructMutator()
     ])
 }
 
@@ -435,20 +435,20 @@ export function isStructType(v) {
 
 export function structTypeInfo(desc) {
     return [
-	desc._options.name,
-	desc._options.initFieldCount,
-	desc._options.autoFieldCount,
-	desc.getStructAccessor(),
-	desc.getStructMutator(),
-	desc._options.immutables, //TODO: What about supers?
-	desc._options.superType || false,
-	false //TODO: Not sure what this field means?
+        desc._options.name,
+        desc._options.initFieldCount,
+        desc._options.autoFieldCount,
+        desc.getStructAccessor(),
+        desc.getStructMutator(),
+        desc._options.immutables, //TODO: What about supers?
+        desc._options.superType || false,
+        false //TODO: Not sure what this field means?
     ];
 }
 
 export function isStructInstance(v) {
     return (v instanceof Struct) ||
-	(v instanceof Function) && (v.__rjs_struct_object instanceof Struct);
+        (v instanceof Function) && (v.__rjs_struct_object instanceof Struct);
 }
 
 export function check(v, desc) {
@@ -458,6 +458,6 @@ export function check(v, desc) {
 /*****************************************************************************/
 // Properties
 
-export let propProcedure =  makeStructTypeProperty({
+export let propProcedure = makeStructTypeProperty({
     name: "prop:procedure"
 }).getAt(0);

--- a/racketscript-compiler/racketscript/compiler/runtime/core/struct.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/struct.js
@@ -174,7 +174,7 @@ class StructTypeDescriptor extends Primitive {
 	}
 
 	// Immutables
-	let immutables = options.immutables || [];
+	let immutables = options.immutables || Pair.EMPTY;
 	this._options.immutables = new Set(Pair.listToArray(immutables));
 	this._options.immutables.forEach((e) => {
 	    if (e < 0 || e >= options.initFieldCount) {

--- a/racketscript-compiler/racketscript/compiler/runtime/core/symbol.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/symbol.js
@@ -1,5 +1,5 @@
-import {Primitive} from "./primitive.js";
-import {internedMake} from "./lib.js";
+import { Primitive } from "./primitive.js";
+import { internedMake } from "./lib.js";
 
 class Symbol extends Primitive {
     constructor(v) {
@@ -9,19 +9,19 @@ class Symbol extends Primitive {
     }
 
     toString() {
-	return this.v;
+        return this.v;
     }
 
     toRawString() {
-	return "'" + this.v;
+        return "'" + this.v;
     }
 
     equals(v) {
-	// Symbols are interned by default, and two symbols
-	// with same name can't be unequal.
-	// Eg. (define x (gensym)) ;;=> 'g60
-	//     (equal? x 'g60)     ;;=> #f
-	return v === this;
+        // Symbols are interned by default, and two symbols
+        // with same name can't be unequal.
+        // Eg. (define x (gensym)) ;;=> 'g60
+        //     (equal? x 'g60)     ;;=> #f
+        return v === this;
     }
 
     /**

--- a/racketscript-compiler/racketscript/compiler/runtime/core/unicode_string.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/unicode_string.js
@@ -1,11 +1,11 @@
-import {Primitive} from "./primitive.js";
+import { Primitive } from "./primitive.js";
 import * as Bytes from "./bytes.js";
 import * as Char from "./char.js";
 import * as Pair from "./pair.js";
 import * as $ from "./lib.js";
-import {internedMake} from "./lib.js";
-import {Encoder as TextEncoder} from "./text_transcoder.js";
-import {hashIntArray} from "./raw_hashing.js";
+import { internedMake } from "./lib.js";
+import { Encoder as TextEncoder } from "./text_transcoder.js";
+import { hashIntArray } from "./raw_hashing.js";
 
 /**
  * A sequence of {Char.Char}s.
@@ -190,9 +190,9 @@ class MutableUString extends UString {
     setCharAt(i, char) {
         this.checkIndexLtLength(i);
         if (!Char.eq(char, this.chars[i])) {
-          this.chars[i] = char;
-          this._nativeString = null;
-          this._cachedHashCode = null;
+            this.chars[i] = char;
+            this._nativeString = null;
+            this._cachedHashCode = null;
         }
     }
 }

--- a/racketscript-compiler/racketscript/compiler/runtime/core/values.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/values.js
@@ -1,26 +1,26 @@
-import {Primitive} from "./primitive.js";
-import {racketCoreError} from "./lib.js";
+import { Primitive } from "./primitive.js";
+import { racketCoreError } from "./lib.js";
 
 class Values extends Primitive {
     constructor(vals) {
-	super();
-	this.v = vals;
+        super();
+        this.v = vals;
     }
 
     toString() {
-	throw racketCoreError("Not Implemented");
+        throw racketCoreError("Not Implemented");
     }
 
     toRawString() {
-	return this.toString();
+        return this.toString();
     }
 
     getAt(i) {
-	return this.v[i];
+        return this.v[i];
     }
 
     getAll() {
-	return this.v;
+        return this.v;
     }
 }
 

--- a/racketscript-compiler/racketscript/compiler/runtime/core/vector.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/vector.js
@@ -1,73 +1,73 @@
-import {Primitive} from "./primitive.js";
-import {isEqual} from "./equality.js";
+import { Primitive } from "./primitive.js";
+import { isEqual } from "./equality.js";
 import * as $ from "./lib.js";
 
 class Vector extends Primitive {
     constructor(items, mutable) {
-	super();
-	this.mutable = mutable;
-	this.items = items;
+        super();
+        this.mutable = mutable;
+        this.items = items;
     }
 
     toString() {
-	let items = "";
-	for (let i = 0; i < this.items.length; i++) {
-	    items += this.items[i].toString();
-	    if (i != this.items.length - 1) {
-		items += " ";
-	    }
-	}
-	return "#(" + items + ")";
+        let items = "";
+        for (let i = 0; i < this.items.length; i++) {
+            items += this.items[i].toString();
+            if (i != this.items.length - 1) {
+                items += " ";
+            }
+        }
+        return "#(" + items + ")";
     }
 
     toRawString() {
-	return "'" + this.toString();
+        return "'" + this.toString();
     }
 
     isImmutable() {
-	    return !this.mutable;
+        return !this.mutable;
     }
 
     ref(n) {
-	if (n < 0 || n > this.items.length) {
-	    throw $.racketCoreError("vector-ref", "index out of range");
-	}
+        if (n < 0 || n > this.items.length) {
+            throw $.racketCoreError("vector-ref", "index out of range");
+        }
 
-	return this.items[n];
+        return this.items[n];
     }
 
     set(n, v) {
-	if (n < 0 || n > this.items.length) {
-	    throw  $.racketCoreError("vector-set", "index out of range");
-	} else if (!this.mutable) {
-	    throw $.racketCoreError("vector-set", "immutable vector");
-	}
-	this.items[n] = v;
+        if (n < 0 || n > this.items.length) {
+            throw $.racketCoreError("vector-set", "index out of range");
+        } else if (!this.mutable) {
+            throw $.racketCoreError("vector-set", "immutable vector");
+        }
+        this.items[n] = v;
     }
 
     length() {
-	return this.items.length;
+        return this.items.length;
     }
 
     equals(v) {
-	if (!check(v)) {
-	    return false;
-	}
+        if (!check(v)) {
+            return false;
+        }
 
-	let items1 = this.items;
-	let items2 = v.items;
+        let items1 = this.items;
+        let items2 = v.items;
 
-	if (items1.length != items2.length) {
-	    return false;
-	}
+        if (items1.length != items2.length) {
+            return false;
+        }
 
-	for (let i = 0; i < items1.length; i++) {
-	    if (!isEqual(items1[i], items2[i])) {
-		return false;
-	    }
-	}
+        for (let i = 0; i < items1.length; i++) {
+            if (!isEqual(items1[i], items2[i])) {
+                return false;
+            }
+        }
 
-	return true;
+        return true;
     }
 }
 

--- a/racketscript-compiler/racketscript/compiler/runtime/kernel.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/kernel.js
@@ -40,7 +40,7 @@ export function format(pattern, ...args) {
 }
 
 export function listToString(lst) {
-	return Core.UString.makeMutableFromChars(
+    return Core.UString.makeMutableFromChars(
         Core.Pair.listToArray(lst));
 }
 
@@ -80,21 +80,21 @@ export function error(...args) {
 
 export function random(...args) {
     switch (args.length) {
-    case 0: return Math.random();
-    case 1:
-	if (args[0] > 0) {
-	    return Math.floor(Math.random() * args[0]);
-        } else {
-	    error("random: argument should be positive");
-        }
-    case 2:
-	if (args[0] > 0 && args[1] > args[0]) {
-	    return Math.floor(args[0] + Math.random() * (args[1] - args[0]));
-	} else {
-	    error("random: invalid arguments");
-	}
-    default:
-	error("random: invalid number of arguments")
+        case 0: return Math.random();
+        case 1:
+            if (args[0] > 0) {
+                return Math.floor(Math.random() * args[0]);
+            } else {
+                error("random: argument should be positive");
+            }
+        case 2:
+            if (args[0] > 0 && args[1] > args[0]) {
+                return Math.floor(args[0] + Math.random() * (args[1] - args[0]));
+            } else {
+                error("random: invalid arguments");
+            }
+        default:
+            error("random: invalid number of arguments")
     }
 }
 
@@ -102,44 +102,44 @@ export function random(...args) {
 
 export function memv(v, lst) {
     while (Core.Pair.isEmpty(lst) == false) {
-	if (Core.isEqv(v, lst.hd)) {
-	    return lst;
-	}
-	lst = lst.tl;
-	continue;
+        if (Core.isEqv(v, lst.hd)) {
+            return lst;
+        }
+        lst = lst.tl;
+        continue;
     }
     return false;
 }
 
 export function memq(v, lst) {
     while (Core.Pair.isEmpty(lst) == false) {
-	if (Core.isEq(v, lst.hd)) {
-	    return lst;
-	}
-	lst = lst.tl;
-	continue;
+        if (Core.isEq(v, lst.hd)) {
+            return lst;
+        }
+        lst = lst.tl;
+        continue;
     }
     return false;
 }
 
 export function memf(f, lst) {
     while (Core.Pair.isEmpty(lst) == false) {
-	if (f(lst.hd)) {
-	    return lst;
-	}
-	lst = lst.tl;
-	continue;
+        if (f(lst.hd)) {
+            return lst;
+        }
+        lst = lst.tl;
+        continue;
     }
     return false;
 }
 
 export function findf(f, lst) {
     while (Core.Pair.isEmpty(lst) == false) {
-	if (f(lst.hd)) {
-	    return list.hd;
-	}
-	lst = lst.tl;
-	continue;
+        if (f(lst.hd)) {
+            return list.hd;
+        }
+        lst = lst.tl;
+        continue;
     }
     return false;
 }
@@ -150,45 +150,46 @@ export function findf(f, lst) {
 export function sort9(lst, cmp) {
     var arr = Core.Pair.listToArray(lst);
     var x2i = new Map();
-    arr.forEach(function (x,i) { x2i.set(x,i); });
-    var srted = arr.sort(function (x,y) {
-	if (cmp(x,y)) {
-	    return -1;
-	} else if (cmp(y,x)) {
-	    return 1;
-	} else { // x = y, simulate stable sort by comparing indices
-	    return x2i.get(x) - x2i.get(y);
-	}});
+    arr.forEach(function (x, i) { x2i.set(x, i); });
+    var srted = arr.sort(function (x, y) {
+        if (cmp(x, y)) {
+            return -1;
+        } else if (cmp(y, x)) {
+            return 1;
+        } else { // x = y, simulate stable sort by comparing indices
+            return x2i.get(x) - x2i.get(y);
+        }
+    });
 
     return Core.Pair.listFromArray(srted);
 }
 
 export function assv(k, lst) {
     while (Core.Pair.isEmpty(lst) === false) {
-	if (Core.isEqv(k, lst.hd.hd)) {
-	    return lst.hd;
-	}
-	lst = lst.tl;
+        if (Core.isEqv(k, lst.hd.hd)) {
+            return lst.hd;
+        }
+        lst = lst.tl;
     }
     return false;
 }
 
 export function assq(k, lst) {
     while (Core.Pair.isEmpty(lst) === false) {
-	if (Core.isEq(k, lst.hd.hd)) {
-	    return lst.hd;
-	}
-	lst = lst.tl;
+        if (Core.isEq(k, lst.hd.hd)) {
+            return lst.hd;
+        }
+        lst = lst.tl;
     }
     return false;
 }
 
 export function assf(f, lst) {
     while (Core.Pair.isEmpty(lst) === false) {
-	if (f(lst.hd.hd)) {
-	    return lst.hd;
-	}
-	lst = lst.tl;
+        if (f(lst.hd.hd)) {
+            return lst.hd;
+        }
+        lst = lst.tl;
     }
     return false;
 }

--- a/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
+++ b/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
@@ -154,9 +154,8 @@
 
 (define-checked+provide (car [pair pair?]) #js.pair.hd)
 (define-checked+provide (cdr [pair pair?]) #js.pair.tl)
-(define+provide cons       #js.Pair.make)
-(define+provide cons?      #js.Pair.check)
-(define+provide pair?      #js.Pair.check)
+(define+provide cons       #js.Core.Pair.make)
+(define+provide pair?      #js.Core.Pair.check)
 
 (define-checked+provide (caar [v (check/pair-of? pair? #t)])
   #js.v.hd.hd)
@@ -169,18 +168,13 @@
 (define-checked+provide (caddr [v (check/pair-of? #t (check/pair-of? #t pair?))])
   #js.v.tl.tl.hd)
 
-(define+provide null  #js.Pair.Empty)
-(define+provide list  #js.Pair.makeList)
+(define+provide null #js.Core.Pair.EMPTY)
+(define+provide list #js.Core.Pair.makeList)
 
-(define+provide null?  #js.Pair.isEmpty)
-(define+provide empty? #js.Pair.isEmpty)
-(define+provide length #js.Pair.listLength)
+(define+provide null? #js.Core.Pair.isEmpty)
+(define+provide list? #js.Core.Pair.isList)
 
-(define+provide (list? v)
-  (cond
-    [(null? v) #t]
-    [(cons? v) (list? ($> v (cdr)))]
-    [else #f]))
+(define-checked+provide (length [v list?]) #js.v.length)
 
 (define-checked+provide (reverse [lst list?])
   (let loop ([lst lst]

--- a/racketscript-compiler/racketscript/compiler/runtime/paramz.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/paramz.js
@@ -1,5 +1,5 @@
 import * as Core from "./core.js";
-import {hamt} from "./core/lib.js";
+import { hamt } from "./core/lib.js";
 
 /* --------------------------------------------------------------------------*/
 // All exports go in exports
@@ -35,21 +35,21 @@ export function getCurrentParameterization() {
 
 export function makeParameter(initValue) {
     let param = function (maybeSetVal) {
-	// Get current value box from parameterization. The function
-	// `param` that we result is the key.
-	let pv = getCurrentParameterization().get(param, false) ||
-	    __top.get(param, false);
-	// Create entry in __top if its a mutation.
-	if (!pv && maybeSetVal !== undefined) {
-	    pv = Box.make(initValue);
-	    __top.set(param, pv);
-	}
-	// Get/Set
-	if (maybeSetVal === undefined) {
-	    return (pv && pv.get()) || initValue;
-	} else {
-	    pv.set(maybeSetVal);
-	}
+        // Get current value box from parameterization. The function
+        // `param` that we result is the key.
+        let pv = getCurrentParameterization().get(param, false) ||
+            __top.get(param, false);
+        // Create entry in __top if its a mutation.
+        if (!pv && maybeSetVal !== undefined) {
+            pv = Box.make(initValue);
+            __top.set(param, pv);
+        }
+        // Get/Set
+        if (maybeSetVal === undefined) {
+            return (pv && pv.get()) || initValue;
+        } else {
+            pv.set(maybeSetVal);
+        }
     }
     return param;
 }
@@ -57,7 +57,7 @@ export function makeParameter(initValue) {
 export function extendParameterization(parameterization, ...args) {
     let result = parameterization;
     for (let i = 0; i < args.length; i += 2) {
-	result = result.set(args[i], Box.make(args[i + 1]));
+        result = result.set(args[i], Box.make(args[i + 1]));
     }
     return result;
 }
@@ -65,7 +65,7 @@ export function extendParameterization(parameterization, ...args) {
 export function copyParameterization(parameterization) {
     let result = hamt.make();
     for (let [key, val] of parameterization) {
-	result = result.set(key, Box.make(val.get()));
+        result = result.set(key, Box.make(val.get()));
     }
     return result;
 }
@@ -76,27 +76,27 @@ export function copyParameterization(parameterization) {
 (function () {
     let p = getCurrentParameterization();
     if (p !== false) {
-	return;
+        return;
     } else {
-	Marks.setMark(ParameterizationKey, hamt.make());
+        Marks.setMark(ParameterizationKey, hamt.make());
     }
     __top = new Map();
 
     Marks.registerAsynCallbackWrapper({
-	onCreate: function (state) {
-	    let paramz = {};
-	    paramz.top = new Map();
-	    for (let [key, val] of __top) {
-		paramz.top.set(key, Box.make(val.get()));
-	    }
+        onCreate: function (state) {
+            let paramz = {};
+            paramz.top = new Map();
+            for (let [key, val] of __top) {
+                paramz.top.set(key, Box.make(val.get()));
+            }
 
-	    paramz.bottom = copyParameterization(
-		Marks.getFirstMark(Marks.getFrames(), ParameterizationKey, false));
-	    state.paramz = paramz;
-	},
-	onInvoke: function (state) {
-	    __top = state.paramz.top;
-	    Marks.setMark(ParameterizationKey, state.paramz.bottom);
-	}
+            paramz.bottom = copyParameterization(
+                Marks.getFirstMark(Marks.getFrames(), ParameterizationKey, false));
+            state.paramz = paramz;
+        },
+        onInvoke: function (state) {
+            __top = state.paramz.top;
+            Marks.setMark(ParameterizationKey, state.paramz.bottom);
+        }
     });
 })();

--- a/racketscript-compiler/racketscript/compiler/transform.rkt
+++ b/racketscript-compiler/racketscript/compiler/transform.rkt
@@ -602,7 +602,7 @@
      (ILApp (name-in-module 'core 'Pair.makeList)
             (map absyn-value->il d))]
     [(empty? d)
-     (name-in-module 'core 'Pair.Empty)]
+     (name-in-module 'core 'Pair.EMPTY)]
     [(cons? d)
      (ILApp (name-in-module 'core 'Pair.make)
             (list (absyn-value->il (car d))

--- a/tests/basic/list.rkt
+++ b/tests/basic/list.rkt
@@ -8,3 +8,17 @@
 (displayln (length (list-sq)))
 
 (equal? '(1 2 3) '(1 2 3))
+(equal? (list 1 2 3) '(1 2 3))
+
+(eq? '() null)
+(null? '())
+(list? '())
+(list? (cons 1 2))
+(list? (cons 1 '()))
+(list? (cons 1 (cons 2 '())))
+(equal? (cons 1 '()) (list 1))
+
+(pair? '())
+(pair? (cons 1 #\x))
+
+(immutable? '())


### PR DESCRIPTION
* Replaces tabs with spaces throughout.
* Add spaces around import braces as per most style guides (Google, AirBnb).
* Fix indentation for statements such as `switch` etc.
* Spaces around default parameters.

Now is good time as there are no outstanding PRs, nor JS runtime work-in-progress that I'm aware of.

Note that this is based on #108 which I assume will get merged by the time you get to this.
You can then rebase this PR with a single click.

GitHub doesn't show tabs vs spaces by default, but you can use this bookmarklet to review: https://gist.github.com/glebm/5b6c4517322193fbc51090dc3b57a44a

```
javascript:(function()%7Bfunction%20e(e%2Co%2Cr)%7Bconst%20c%3De.nodeValue.split(%22%5Ct%22).map(e%3D%3Ee.split(%22%20%22))%3Bif(1%3D%3D%3Dc.length%26%261%3D%3D%3Dc%5B0%5D.length)return%3Bconst%20a%3De.parentNode%2Cd%3Dt%3D%3E%7Ba.insertBefore(t%2Ce)%7D%3Bn(c%2Ce%3D%3E1%3D%3D%3De.length%26%26%22%22%3D%3D%3De%5B0%5D%2Ce%3D%3Ed(t(o.repeat(e)))%2Ce%3D%3En(e%2Ce%3D%3E%22%22%3D%3D%3De%2Ce%3D%3Ed(t(r.repeat(e)))%2Ce%3D%3Ed(document.createTextNode(e))))%2Ca.removeChild(e)%7Dfunction%20t(e)%7Bconst%20t%3Ddocument.createElement(%22span%22)%3Breturn%20t.textContent%3De%2Ct.style.opacity%3Dc%2Ct%7Dfunction%20n(e%2Ct%2Cn%2Co)%7Bconst%20r%3De.length%3Be.reduce((e%2Cc%2Ca)%3D%3E%7Bconst%20d%3Dt(c)%3Breturn%20d%26%26a!%3D%3Dr-1%3Fe%2B1%3A(e%3E0%26%26n(e)%2Cd%7C%7Co(c)%2C1)%7D%2C0)%7Dvar%20o%3D%22%C2%B7%22%2Cr%3D%22%E2%86%92%22%2Cc%3D.8%3B!function()%7Bfor(const%20t%20of%20document.querySelectorAll(%22table%5Bdata-tab-size%5D%22))%7Bconst%20n%3Dr.padEnd(%2Bt.dataset.tabSize)%2Cc%3Ddocument.createTreeWalker(t%2CNodeFilter.SHOW_TEXT%2C%7BacceptNode(e)%7Blet%20t%3De.parentNode%3Bfor(%3B%22TABLE%22!%3Dt.nodeName%3B)%7Bif(t.classList.contains(%22blob-code-inner%22))return%20t.firstChild!%3D%3De%7C%7C%22%20%22!%3D%3De.nodeValue%3FNodeFilter.FILTER_ACCEPT%3ANodeFilter.FILTER_SKIP%3Bt%3Dt.parentNode%7Dreturn%20NodeFilter.FILTER_SKIP%7D%7D)%2Ca%3D%5B%5D%3Bfor(%3Bc.nextNode()%3B)a.push(c.currentNode)%3Bfor(const%20t%20of%20a)e(t%2Cn%2Co)%7D%7D()%7D)()
```