### PR TITLE
A minor fix to JSDoc types to make tscheck run

### DIFF
--- a/racketscript-compiler/racketscript/compiler/runtime/core/char.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/char.js
@@ -79,7 +79,7 @@ export class Char extends Primitive {
 const INTERN_CACHE_SIZE = 256;
 
 /**
- * @type {!Array<(!Char|undefined)>} A cache for chars with small codepoints.
+ * @type {!Array<Char|undefined>} A cache for chars with small codepoints.
  */
 const internedCache = new Array(INTERN_CACHE_SIZE);
 

--- a/racketscript-compiler/racketscript/compiler/runtime/core/raw_hashing.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/raw_hashing.js
@@ -77,7 +77,7 @@ export function hashNumber(n) {
 /**
  * A weak map to the object's ID for {hashObjectIdentity}.
  *
- * @type {!WeakMap<!Object, number>}
+ * @type {!WeakMap<Object, number>}
  */
 const objectIds = new WeakMap();
 let currentId = 0;


### PR DESCRIPTION
A follow-up to #102

It's kinda useless to run it on the entire project, as unlike actual TypeScript types, JSDoc types are not powerful enough to express our contracts. However, I found that it helps a lot to run it on individual files while developing (still catches a ton of issues).