### PR TITLE
Update .eslintrc `make eslint-fix`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,32 @@
     },
     "rules": {
         "indent": ["error", 4],
-        "import/extensions": ["error", "always"]
+        "import/extensions": ["error", "always"],
+        "comma-dangle": ["error", "never"],
+        "no-bitwise": ["error", { "allow": ["~"] }],
+        "no-underscore-dangle": ["error", { "allowAfterThis": true }],
+        "no-use-before-define": [
+            "error",
+            {
+                "functions": false,
+                "classes": true,
+                "variables": true
+            }
+        ],
+        "no-restricted-syntax": [
+            "error",
+            {
+              "selector": "ForInStatement",
+              "message": "for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array."
+            },
+            {
+              "selector": "LabeledStatement",
+              "message": "Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand."
+            },
+            {
+              "selector": "WithStatement",
+              "message": "`with` is disallowed in strict mode because it makes code impossible to predict and optimize."
+            }
+        ]
     }
 }

--- a/racketscript-compiler/racketscript/compiler/runtime/core.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core.js
@@ -1,22 +1,22 @@
 // Exports classes for creating basic data types and operation on them
 
-import * as Box from "./core/box.js";
-import * as Bytes from "./core/bytes.js";
-import * as Char from "./core/char.js";
-import * as UString from "./core/unicode_string.js";
-import * as Regexp from "./core/regexp.js";
-import * as Hash from "./core/hash.js";
-import * as Keyword from "./core/keyword.js";
-import * as Number from "./core/numbers.js";
-import * as Pair from "./core/pair.js";
-import * as Ports from "./core/ports.js";
-import * as Primitive from "./core/primitive.js";
-import * as Struct from "./core/struct.js";
-import * as Symbol from "./core/symbol.js";
-import * as Values from "./core/values.js";
-import * as Vector from "./core/vector.js";
-import * as Marks from "./core/marks.js";
-import * as MPair from "./core/mpair.js";
+import * as Box from './core/box.js';
+import * as Bytes from './core/bytes.js';
+import * as Char from './core/char.js';
+import * as UString from './core/unicode_string.js';
+import * as Regexp from './core/regexp.js';
+import * as Hash from './core/hash.js';
+import * as Keyword from './core/keyword.js';
+import * as Number from './core/numbers.js';
+import * as Pair from './core/pair.js';
+import * as Ports from './core/ports.js';
+import * as Primitive from './core/primitive.js';
+import * as Struct from './core/struct.js';
+import * as Symbol from './core/symbol.js';
+import * as Values from './core/values.js';
+import * as Vector from './core/vector.js';
+import * as Marks from './core/marks.js';
+import * as MPair from './core/mpair.js';
 
 
 export {
@@ -37,7 +37,7 @@ export {
     UString,
     Regexp,
     MPair
-}
+};
 
 export {
     toString,
@@ -48,25 +48,25 @@ export {
 
     racketCoreError,
     racketContractError
-} from "./core/lib.js";
+} from './core/lib.js';
 
 export {
-    attachProcedureArity,
-} from "./core/procedure.js";
+    attachProcedureArity
+} from './core/procedure.js';
 
 export {
     isEq,
     isEqv,
-    isEqual,
-} from "./core/equality.js";
+    isEqual
+} from './core/equality.js';
 
 export {
     hashForEq,
     hashForEqv,
-    hashForEqual,
-} from "./core/hashing.js";
+    hashForEqual
+} from './core/hashing.js';
 
-//;-----------------------------------------------------------------------------
+// ;-----------------------------------------------------------------------------
 
 export function bitwiseNot(a) {
     return ~a;

--- a/racketscript-compiler/racketscript/compiler/runtime/core/box.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/box.js
@@ -1,5 +1,5 @@
-import { Primitive } from "./primitive.js";
-import { isEqual } from "./equality.js";
+import { Primitive } from './primitive.js';
+import { isEqual } from './equality.js';
 
 class Box extends Primitive {
     constructor(v) {
@@ -34,5 +34,5 @@ export function make(v) {
 }
 
 export function check(v) {
-    return (v instanceof Box)
+    return (v instanceof Box);
 }

--- a/racketscript-compiler/racketscript/compiler/runtime/core/bytes.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/bytes.js
@@ -1,4 +1,4 @@
-import { hashIntArray } from "./raw_hashing.js";
+import { hashIntArray } from './raw_hashing.js';
 
 // In node.js, TextDecoder is not global and needs to be imported.
 if (typeof TextDecoder === 'undefined') {

--- a/racketscript-compiler/racketscript/compiler/runtime/core/char.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/char.js
@@ -1,4 +1,4 @@
-import { Primitive } from "./primitive.js";
+import { Primitive } from './primitive.js';
 
 /**
  * A single Unicode character.
@@ -162,7 +162,6 @@ export function charUtf8Length(c) {
         return 4;
     } else if (cp < 0x4000000) {
         return 5;
-    } else {
-        return 6;
     }
+    return 6;
 }

--- a/racketscript-compiler/racketscript/compiler/runtime/core/check.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/check.js
@@ -2,22 +2,22 @@ export function raise(exp, ...args) {
     throw exp.apply(this, args);
 }
 
-export function truthy(val, exp, msg = "") {
+export function truthy(val, exp, msg = '') {
     if (val !== true) {
         raise(exp, msg);
     }
     return true;
 }
 
-export function falsy(val, exp, msg = "") {
+export function falsy(val, exp, msg = '') {
     return truthy(val === false, exp, msg);
 }
 
-export function type(val, type, msg = "") {
+export function type(val, type, msg = '') {
     if (val instanceof type) {
         return true;
     }
-    raise(TypeError, msg + "(" + val + " : " + typeof (val) + " != " + type.name + ")");
+    raise(TypeError, `${msg}(${val} : ${typeof (val)} != ${type.name})`);
 }
 
 export function eq(val1, val2, exp, msg) {

--- a/racketscript-compiler/racketscript/compiler/runtime/core/equality.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/equality.js
@@ -1,6 +1,6 @@
-import * as Primitive from "./primitive.js";
-import * as Char from "./char.js";
-import * as Bytes from "./bytes.js";
+import * as Primitive from './primitive.js';
+import * as Char from './char.js';
+import * as Bytes from './bytes.js';
 
 /**
  * @param {*} v1

--- a/racketscript-compiler/racketscript/compiler/runtime/core/hash.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/hash.js
@@ -1,8 +1,8 @@
-import * as $ from "./lib.js";
-import * as Pair from "./pair.js";
-import { Primitive } from "./primitive.js";
-import { isEqual, isEqv, isEq } from "./equality.js";
-import { hashForEqual, hashForEqv, hashForEq } from "./hashing.js";
+import * as $ from './lib.js';
+import * as Pair from './pair.js';
+import { Primitive } from './primitive.js';
+import { isEqual, isEqv, isEq } from './equality.js';
+import { hashForEqual, hashForEqv, hashForEq } from './hashing.js';
 
 const hashConfigs = {
     eq: {
@@ -17,7 +17,7 @@ const hashConfigs = {
         hash: hashForEqual,
         keyEq: isEqual
     }
-}
+};
 
 class Hash extends Primitive {
     constructor(hash, type, mutable) {
@@ -29,7 +29,7 @@ class Hash extends Primitive {
 
     toString() {
         const items = [];
-        for (let [k, v] of this._h) {
+        for (const [k, v] of this._h) {
             items.push(`(${$.toString(k)} . ${$.toString(v)})`);
         }
         let typeSuffix = '';
@@ -40,7 +40,7 @@ class Hash extends Primitive {
     }
 
     toRawString() {
-        return "'" + this.toString();
+        return `'${this.toString()}`;
     }
 
     isImmutable() {
@@ -48,19 +48,17 @@ class Hash extends Primitive {
     }
 
     ref(k, fail) {
-        let result = this._h.get(k);
+        const result = this._h.get(k);
         if (result !== undefined) {
             return result;
         } else if (fail !== undefined) {
             return fail;
-        } else {
-            throw $.racketCoreError(
-                `hash-ref: no value found for key\n  key: ${$.toString(k)}`);
         }
+        throw $.racketCoreError(`hash-ref: no value found for key\n  key: ${$.toString(k)}`);
     }
 
     set(k, v) {
-        let newH = this._h.set(k, v);
+        const newH = this._h.set(k, v);
 
         if (this._mutable) {
             this._h = newH;
@@ -83,8 +81,8 @@ class Hash extends Primitive {
             return false;
         }
 
-        for (let [key, val] of this._h) {
-            let vv = v._h.get(key);
+        for (const [key, val] of this._h) {
+            const vv = v._h.get(key);
             if (vv === undefined || !isEqual(val, vv)) {
                 return false;
             }
@@ -95,27 +93,27 @@ class Hash extends Primitive {
 }
 
 function make(items, type, mutable) {
-    let h = items.reduce((acc, item) => {
-        let [k, v] = item;
+    const h = items.reduce((acc, item) => {
+        const [k, v] = item;
         return acc.set(k, v);
     }, $.hamt.make(hashConfigs[type]));
     return new Hash(h, type, mutable);
 }
 
 export function makeEq(items, mutable) {
-    return make(items, "eq", mutable);
+    return make(items, 'eq', mutable);
 }
 
 export function makeEqv(items, mutable) {
-    return make(items, "eqv", mutable);
+    return make(items, 'eqv', mutable);
 }
 
 export function makeEqual(items, mutable) {
-    return make(items, "equal", mutable);
+    return make(items, 'equal', mutable);
 }
 
 function makeFromAssocs(assocs, type, mutable) {
-    let items = []
+    const items = [];
     Pair.listForEach(assocs, (item) => {
         items.push([item.hd, item.tl]);
     });
@@ -137,7 +135,7 @@ export function makeEqualFromAssocs(assocs, mutable) {
 export function map(hash, proc) {
     let result = Pair.EMPTY;
     hash._h.forEach((value, key) => {
-        result = Pair.make(proc(key, value), result)
+        result = Pair.make(proc(key, value), result);
     });
     return result;
 }
@@ -147,11 +145,11 @@ export function check(v1) {
 }
 
 export function isEqualHash(h) {
-    return check(h) && h._type === "equal";
+    return check(h) && h._type === 'equal';
 }
 export function isEqvHash(h) {
-    return check(h) && h._type === "eqv";
+    return check(h) && h._type === 'eqv';
 }
 export function isEqHash(h) {
-    return check(h) && h._type === "eq";
+    return check(h) && h._type === 'eq';
 }

--- a/racketscript-compiler/racketscript/compiler/runtime/core/hashing.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/hashing.js
@@ -1,7 +1,7 @@
-import { hash } from "./raw_hashing.js";
-import * as Primitive from "./primitive.js";
-import * as Char from "./char.js";
-import * as Bytes from "./bytes.js";
+import { hash } from './raw_hashing.js';
+import * as Primitive from './primitive.js';
+import * as Char from './char.js';
+import * as Bytes from './bytes.js';
 
 /**
  * @param {*} o

--- a/racketscript-compiler/racketscript/compiler/runtime/core/keyword.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/keyword.js
@@ -1,5 +1,5 @@
-import { Primitive } from "./primitive.js";
-import { internedMake } from "./lib.js";
+import { Primitive } from './primitive.js';
+import { internedMake } from './lib.js';
 
 class Keyword extends Primitive {
     constructor(v) {
@@ -12,7 +12,7 @@ class Keyword extends Primitive {
     }
 
     toRawString() {
-        return "'" + this.v;
+        return `'${this.v}`;
     }
 
     equals(v) {
@@ -21,10 +21,8 @@ class Keyword extends Primitive {
 }
 
 
-export let make = internedMake(v => {
-    return new Keyword(v);
-});
+export const make = internedMake(v => new Keyword(v));
 
 export function check(v) {
-    return (v instanceof Keyword)
+    return (v instanceof Keyword);
 }

--- a/racketscript-compiler/racketscript/compiler/runtime/core/lib.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/lib.js
@@ -1,9 +1,9 @@
-export { hamt } from "../third-party/hamt.js";
+export { hamt } from '../third-party/hamt.js';
 
 // Because we don't have a wrapper type for bytes,
 // we depend on it here for type-checking and toString conversion.
 // TODO: extract toString to a separate file.
-import * as Bytes from "./bytes.js";
+import * as Bytes from './bytes.js';
 
 /* --------------------------------------------------------------------------*/
 /* Strings */
@@ -13,19 +13,17 @@ import * as Bytes from "./bytes.js";
  * @return {!String}
  */
 export function toString(v) {
-    if (v === true) return "#t";
-    if (v === false) return "#f";
-    if (v === undefined || v === null) return "#<void>";
+    if (v === true) return '#t';
+    if (v === false) return '#f';
+    if (v === undefined || v === null) return '#<void>';
     if (Bytes.check(v)) return Bytes.toString(v);
     return v.toString();
 }
 
 export function format1(pattern, args) {
-    return pattern.toString().replace(/{(\d+)}/g, function (match, number) {
-        return typeof args[number] != 'undefined'
-            ? args[number]
-            : match;
-    });
+    return pattern.toString().replace(/{(\d+)}/g, (match, number) => (typeof args[number] !== 'undefined'
+        ? args[number]
+        : match));
 }
 
 export function format(pattern, ...args) {
@@ -36,7 +34,7 @@ export function format(pattern, ...args) {
 /* Errors */
 
 function makeError(name) {
-    let e = function (pattern, ...args) {
+    const e = function (pattern, ...args) {
         this.name = name;
         this.message = format1(pattern, args);
         this.stack = (new Error()).stack;
@@ -45,16 +43,16 @@ function makeError(name) {
         } else {
             this.stack = (new Error()).stack;
         }
-    }
+    };
     e.prototype = Object.create(Error.prototype);
     e.prototype.constructor = e;
 
     return (...args) =>
-        new (Function.prototype.bind.apply(e, [this].concat(args)))
+        new (Function.prototype.bind.apply(e, [this].concat(args)))();
 }
 
-export let racketCoreError = makeError("RacketCoreError");
-export let racketContractError = makeError("RacketContractError");
+export const racketCoreError = makeError('RacketCoreError');
+export const racketContractError = makeError('RacketContractError');
 
 /* --------------------------------------------------------------------------*/
 /* Other Helpers */
@@ -82,13 +80,13 @@ export function attachReadOnlyProperty(o, k, v) {
 }
 
 export function internedMake(f) {
-    let cache = {};
+    const cache = {};
     return (v) => {
         if (v in cache) {
             return cache[v];
         }
-        let result = f(v);
+        const result = f(v);
         cache[v] = result;
         return result;
-    }
+    };
 }

--- a/racketscript-compiler/racketscript/compiler/runtime/core/mpair.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/mpair.js
@@ -1,7 +1,7 @@
-import { Primitive } from "./primitive.js";
-import { isEqual } from "./equality.js";
-import * as $ from "./lib.js";
-import { EMPTY, isEmpty, isList } from "./pair.js";
+import { Primitive } from './primitive.js';
+import { isEqual } from './equality.js';
+import * as $ from './lib.js';
+import { EMPTY, isEmpty, isList } from './pair.js';
 
 class MPair extends Primitive {
     /** @private */
@@ -35,7 +35,7 @@ class MPair extends Primitive {
     }
 
     toRawString() {
-        return "'" + this.toString();
+        return `'${this.toString()}`;
     }
 
     equals(v) {

--- a/racketscript-compiler/racketscript/compiler/runtime/core/numbers.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/numbers.js
@@ -1,51 +1,44 @@
-import * as $ from "./lib.js";
+import * as $ from './lib.js';
 
 /* Arithmetic */
 
 export function add(...operands) {
-    return [].reduce.call(operands, function (a, b) {
-        return a + b
-    }, 0);
+    return [].reduce.call(operands, (a, b) => a + b, 0);
 }
 
 export function sub(...operands) {
     if (operands.length === 1) {
         return -operands[0];
-    } else {
-        let result = operands[0];
-        for (var i = 1; i < operands.length; ++i) {
-            result -= operands[i];
-        }
-        return result;
     }
+    let result = operands[0];
+    for (let i = 1; i < operands.length; ++i) {
+        result -= operands[i];
+    }
+    return result;
 }
 
 export function mul(...operands) {
-    return [].reduce.call(operands, function (a, b) {
-        return a * b
-    }, 1);
+    return [].reduce.call(operands, (a, b) => a * b, 1);
 }
 
 export function div(...operands) {
     if (operands.length === 1) {
         return 1 / operands[0];
-    } else {
-        var result = operands[0];
-        for (var i = 1; i < operands.length; ++i) {
-            result /= operands[i];
-        }
-        return result;
     }
+    let result = operands[0];
+    for (let i = 1; i < operands.length; ++i) {
+        result /= operands[i];
+    }
+    return result;
 }
 
 /* Comparison */
 
 export function compare(cmp, operands) {
     if (operands.length < 2) {
-        throw $.racketCoreError("compare {0}",
-            "atleast 2 arguments required");
+        throw $.racketCoreError('compare {0}', 'atleast 2 arguments required');
     }
-    for (var i = 1; i < operands.length; i++) {
+    for (let i = 1; i < operands.length; i++) {
         if (!cmp(operands[i - 1], operands[i])) {
             return false;
         }
@@ -54,23 +47,23 @@ export function compare(cmp, operands) {
 }
 
 export function lt(...operands) {
-    return compare(function (a, b) { return a < b }, operands)
+    return compare((a, b) => a < b, operands);
 }
 
 export function lte(...operands) {
-    return compare(function (a, b) { return a <= b }, operands)
+    return compare((a, b) => a <= b, operands);
 }
 
 export function gt(...operands) {
-    return compare(function (a, b) { return a > b }, operands)
+    return compare((a, b) => a > b, operands);
 }
 
 export function gte(...operands) {
-    return compare(function (a, b) { return a >= b }, operands)
+    return compare((a, b) => a >= b, operands);
 }
 
 export function equals(...operands) {
-    return compare(function (a, b) { return a === b }, operands)
+    return compare((a, b) => a === b, operands);
 }
 
 export function check(v) {

--- a/racketscript-compiler/racketscript/compiler/runtime/core/pair.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/pair.js
@@ -1,6 +1,6 @@
-import { Primitive } from "./primitive.js";
-import { isEqual } from "./equality.js";
-import * as $ from "./lib.js";
+import { Primitive } from './primitive.js';
+import { isEqual } from './equality.js';
+import * as $ from './lib.js';
 
 /** @singleton */
 class Empty extends Primitive {
@@ -13,11 +13,11 @@ class Empty extends Primitive {
     }
 
     toString() {
-	return "()";
+        return '()';
     }
 
     toRawString() {
-	return "'()";
+        return "'()";
     }
 
     /**
@@ -72,7 +72,7 @@ export class Pair extends Primitive {
     }
 
     toRawString() {
-        return "'" + this.toString();
+        return `'${this.toString()}`;
     }
 
     equals(v) {
@@ -99,7 +99,7 @@ export class Pair extends Primitive {
         }
     }
 
-	/**
+    /**
      * @return {!number}
      */
     hashForEqual() {
@@ -144,14 +144,12 @@ export function make(hd, tl) {
 }
 
 export function makeList(...items) {
-    return items.reduceRight((result, item) => {
-        return make(item, result);
-    }, EMPTY);
+    return items.reduceRight((result, item) => make(item, result), EMPTY);
 }
 
 export function listToArray(lst) {
-    let r = [];
-    listForEach(lst, (x) => r.push(x));
+    const r = [];
+    listForEach(lst, x => r.push(x));
     return r;
 }
 
@@ -168,7 +166,7 @@ export function listForEach(lst, fn) {
 
 export function listFind(lst, fn) {
     while (!isEmpty(lst)) {
-        let result = fn(lst.hd);
+        const result = fn(lst.hd);
         if (result !== false) {
             return result;
         }
@@ -178,8 +176,8 @@ export function listFind(lst, fn) {
 }
 
 export function listMap(lst, fn) {
-    let result = [];
-    let mapper = (x) => result.push(result, fn(x));
+    const result = [];
+    const mapper = x => result.push(result, fn(x));
     listForEach(lst, mapper);
     return listFromArray(result);
 }

--- a/racketscript-compiler/racketscript/compiler/runtime/core/ports.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/ports.js
@@ -1,6 +1,6 @@
-import { Primitive } from "./primitive.js";
-import * as $ from "./lib.js";
-import * as UString from "./unicode_string.js";
+import { Primitive } from './primitive.js';
+import * as $ from './lib.js';
+import * as UString from './unicode_string.js';
 
 class AbstractPort extends Primitive {
     isOutputPort() {
@@ -14,7 +14,7 @@ class AbstractPort extends Primitive {
 
 class AbstractOutputPort extends AbstractPort {
     write() {
-        throw new Error(`Expected ${this.constructor.name} to implement write(chars)`)
+        throw new Error(`Expected ${this.constructor.name} to implement write(chars)`);
     }
 
     isOutputPort() {
@@ -66,11 +66,11 @@ class NewlineFlushingOutputPort extends AbstractOutputPort {
     }
 }
 
-export const standardOutputPort = new NewlineFlushingOutputPort((str) => console.log(str));
-export let currentOutputPort = standardOutputPort;
+export const standardOutputPort = new NewlineFlushingOutputPort(str => console.log(str));
+export const currentOutputPort = standardOutputPort;
 
-export const standardErrorPort = new NewlineFlushingOutputPort((str) => console.log(str));
-export let currentErrorPort = standardErrorPort;
+export const standardErrorPort = new NewlineFlushingOutputPort(str => console.log(str));
+export const currentErrorPort = standardErrorPort;
 
 
 class OutputStringPort extends AbstractOutputPort {
@@ -91,7 +91,6 @@ class OutputStringPort extends AbstractOutputPort {
             return UString.makeMutable('');
         }
         if (this.__buffer.length > 1) {
-
             this.__buffer = [UString.stringAppend(...this.__buffer)];
         }
         return UString.copyAsMutable(this.__buffer[0]);

--- a/racketscript-compiler/racketscript/compiler/runtime/core/primitive.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/primitive.js
@@ -1,5 +1,5 @@
-import * as $ from "./lib.js";
-import { hashString } from "./raw_hashing.js";
+import * as $ from './lib.js';
+import { hashString } from './raw_hashing.js';
 
 /**
  * Base class for various compound data types
@@ -25,7 +25,7 @@ export class Primitive {
      * @return {!String} The string representation matching Racket's `display`.
      */
     toString() {
-        throw $.racketCoreError("Not Implemented");
+        throw $.racketCoreError('Not Implemented');
     }
 
     /**
@@ -36,7 +36,7 @@ export class Primitive {
     }
 
     isImmutable() {
-        throw $.racketCoreError("Not Implemented");;
+        throw $.racketCoreError('Not Implemented');
     }
 
     /**
@@ -44,7 +44,7 @@ export class Primitive {
      * @return {!boolean}
      */
     equals(v) {
-        throw $.racketCoreError("Not Implemented {0}", v);
+        throw $.racketCoreError('Not Implemented {0}', v);
     }
 
     /**

--- a/racketscript-compiler/racketscript/compiler/runtime/core/raw_hashing.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/raw_hashing.js
@@ -15,13 +15,13 @@
 export function hash(o) {
     if (o === null) return 0;
     switch (typeof o) {
-        case 'number': return hashNumber(o);
-        case 'string': return hashString(o);
-        case 'boolean': return o ? 1 : -1;
-        case 'undefined': return 0;
-        case 'object':
-        case 'function': return hashObjectIdentity(o);
-        default: return hashString(o.toString());
+    case 'number': return hashNumber(o);
+    case 'string': return hashString(o);
+    case 'boolean': return o ? 1 : -1;
+    case 'undefined': return 0;
+    case 'object':
+    case 'function': return hashObjectIdentity(o);
+    default: return hashString(o.toString());
     }
 }
 

--- a/racketscript-compiler/racketscript/compiler/runtime/core/regexp.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/regexp.js
@@ -1,7 +1,7 @@
-import * as Bytes from "./bytes.js";
-import * as UString from "./unicode_string.js";
-import * as Pair from "./pair.js";
-import * as $ from "./lib.js";
+import * as Bytes from './bytes.js';
+import * as UString from './unicode_string.js';
+import * as Pair from './pair.js';
+import * as $ from './lib.js';
 
 /**
  * @param {*} v
@@ -35,7 +35,7 @@ export function match(pattern, input) {
 
     if (!(isRegexpPattern || isBytesPattern || isStringPattern)
         || !(isBytesInput || isStringInput)) {
-        throw $.racketContractError("expected regexp, string or byte pat, and string or byte input");
+        throw $.racketContractError('expected regexp, string or byte pat, and string or byte input');
     }
 
     /** @type {!UString.UString} */
@@ -54,18 +54,11 @@ export function match(pattern, input) {
         return false;
     }
     if ((isStringPattern || isRegexpPattern) && isStringInput) {
-        return Pair.listFromArray(
-            result.map(x => {
-                return x !== undefined
-                    ? UString.makeMutable(x)
-                    : false
-            }));
+        return Pair.listFromArray(result.map(x => (x !== undefined
+            ? UString.makeMutable(x)
+            : false)));
     }
-    return Pair.listFromArray(
-        result.map(x => {
-            return x !== undefined
-                ? UString.toBytesUtf8(x)
-                : false
-        }));
-
+    return Pair.listFromArray(result.map(x => (x !== undefined
+        ? UString.toBytesUtf8(x)
+        : false)));
 }

--- a/racketscript-compiler/racketscript/compiler/runtime/core/symbol.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/symbol.js
@@ -1,5 +1,5 @@
-import { Primitive } from "./primitive.js";
-import { internedMake } from "./lib.js";
+import { Primitive } from './primitive.js';
+import { internedMake } from './lib.js';
 
 class Symbol extends Primitive {
     constructor(v) {
@@ -13,7 +13,7 @@ class Symbol extends Primitive {
     }
 
     toRawString() {
-        return "'" + this.v;
+        return `'${this.v}`;
     }
 
     equals(v) {
@@ -36,12 +36,10 @@ class Symbol extends Primitive {
 }
 
 
-export let make = internedMake(v => {
-    return new Symbol(v.toString());
-});
+export const make = internedMake(v => new Symbol(v.toString()));
 
-export let makeUninterned = v => new Symbol(v);
+export const makeUninterned = v => new Symbol(v);
 
 export function check(v) {
-    return (v instanceof Symbol)
+    return (v instanceof Symbol);
 }

--- a/racketscript-compiler/racketscript/compiler/runtime/core/unicode_string.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/unicode_string.js
@@ -1,10 +1,10 @@
-import { Primitive } from "./primitive.js";
-import * as Bytes from "./bytes.js";
-import * as Char from "./char.js";
-import * as Pair from "./pair.js";
-import * as $ from "./lib.js";
-import { internedMake } from "./lib.js";
-import { hashIntArray } from "./raw_hashing.js";
+import { Primitive } from './primitive.js';
+import * as Bytes from './bytes.js';
+import * as Char from './char.js';
+import * as Pair from './pair.js';
+import * as $ from './lib.js';
+import { internedMake } from './lib.js';
+import { hashIntArray } from './raw_hashing.js';
 
 // In node.js, TextEncoder is not global and needs to be imported.
 if (typeof TextEncoder === 'undefined') {
@@ -99,13 +99,12 @@ export class UString extends Primitive {
      */
     checkIndexLtLength(i) {
         if (i >= this.length) {
-            throw $.racketContractError(
-                this.length > 0
-                    ? `string-ref: index is out of range
+            throw $.racketContractError(this.length > 0
+                ? `string-ref: index is out of range
   index: ${i}
   valid range: [0, ${this.length - 1}]
   string: ${this.toRawString()}`
-                    : `string-ref: index is out of range for empty string
+                : `string-ref: index is out of range for empty string
   index: ${i}`);
         }
     }
@@ -166,7 +165,6 @@ class ImmutableUString extends UString {
  * See {Char.Char} for implementation notes.
  */
 class ImmutableBMPString extends ImmutableUString {
-
     /**
      * @param {!number} start
      * @param {!number} end
@@ -176,7 +174,8 @@ class ImmutableBMPString extends ImmutableUString {
     substring(start, end) {
         return new MutableUString(
             this.chars.slice(start, end),
-            this.toString().substring(start, end));
+            this.toString().substring(start, end)
+        );
     }
 }
 
@@ -214,9 +213,7 @@ function nativeStringToChars(nativeString) {
  * @param {!string} nativeString
  * @return {!ImmutableUString}
  */
-export let makeInternedImmutable = internedMake(nativeString => {
-    return makeImmutable(nativeString);
-});
+export const makeInternedImmutable = internedMake(nativeString => makeImmutable(nativeString));
 
 /**
  * @param {!string} nativeString
@@ -225,7 +222,8 @@ export let makeInternedImmutable = internedMake(nativeString => {
 export function makeImmutable(nativeString) {
     return makeImmutableFromCharsAndNativeString(
         nativeStringToChars(nativeString),
-        nativeString);
+        nativeString
+    );
 }
 
 /**
@@ -246,7 +244,8 @@ function makeImmutableFromCharsAndNativeString(chars, nativeString) {
 export function makeMutable(nativeString) {
     return new MutableUString(
         nativeStringToChars(nativeString),
-        nativeString);
+        nativeString
+    );
 }
 
 /**
@@ -392,8 +391,7 @@ export function fromBytesUtf8(bytes) {
  * @return {!MutableUString}
  */
 export function stringAppend(...strs) {
-    return makeMutableFromChars(
-        [].concat(...strs.map(s => s.chars)));
+    return makeMutableFromChars([].concat(...strs.map(s => s.chars)));
 }
 
 const TRUE_STRING = makeInternedImmutable($.toString(true));

--- a/racketscript-compiler/racketscript/compiler/runtime/core/values.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/values.js
@@ -1,5 +1,5 @@
-import { Primitive } from "./primitive.js";
-import { racketCoreError } from "./lib.js";
+import { Primitive } from './primitive.js';
+import { racketCoreError } from './lib.js';
 
 class Values extends Primitive {
     constructor(vals) {
@@ -8,7 +8,7 @@ class Values extends Primitive {
     }
 
     toString() {
-        throw racketCoreError("Not Implemented");
+        throw racketCoreError('Not Implemented');
     }
 
     toRawString() {

--- a/racketscript-compiler/racketscript/compiler/runtime/core/vector.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/vector.js
@@ -1,6 +1,6 @@
-import { Primitive } from "./primitive.js";
-import { isEqual } from "./equality.js";
-import * as $ from "./lib.js";
+import { Primitive } from './primitive.js';
+import { isEqual } from './equality.js';
+import * as $ from './lib.js';
 
 class Vector extends Primitive {
     constructor(items, mutable) {
@@ -10,18 +10,18 @@ class Vector extends Primitive {
     }
 
     toString() {
-        let items = "";
+        let items = '';
         for (let i = 0; i < this.items.length; i++) {
             items += this.items[i].toString();
             if (i != this.items.length - 1) {
-                items += " ";
+                items += ' ';
             }
         }
-        return "#(" + items + ")";
+        return `#(${items})`;
     }
 
     toRawString() {
-        return "'" + this.toString();
+        return `'${this.toString()}`;
     }
 
     isImmutable() {
@@ -30,7 +30,7 @@ class Vector extends Primitive {
 
     ref(n) {
         if (n < 0 || n > this.items.length) {
-            throw $.racketCoreError("vector-ref", "index out of range");
+            throw $.racketCoreError('vector-ref', 'index out of range');
         }
 
         return this.items[n];
@@ -38,9 +38,9 @@ class Vector extends Primitive {
 
     set(n, v) {
         if (n < 0 || n > this.items.length) {
-            throw $.racketCoreError("vector-set", "index out of range");
+            throw $.racketCoreError('vector-set', 'index out of range');
         } else if (!this.mutable) {
-            throw $.racketCoreError("vector-set", "immutable vector");
+            throw $.racketCoreError('vector-set', 'immutable vector');
         }
         this.items[n] = v;
     }
@@ -54,8 +54,8 @@ class Vector extends Primitive {
             return false;
         }
 
-        let items1 = this.items;
-        let items2 = v.items;
+        const items1 = this.items;
+        const items2 = v.items;
 
         if (items1.length != items2.length) {
             return false;
@@ -81,7 +81,7 @@ export function copy(vec, mutable) {
 
 
 export function makeInit(size, init) {
-    let r = new Array(size);
+    const r = new Array(size);
     r.fill(init);
     return new Vector(r, true);
 }

--- a/racketscript-compiler/racketscript/compiler/runtime/kernel.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/kernel.js
@@ -1,4 +1,4 @@
-import * as Core from "./core.js";
+import * as Core from './core.js';
 
 /* --------------------------------------------------------------------------*/
 // Immutable
@@ -8,40 +8,36 @@ export function isImmutable(v) {
         return v.isImmutable();
     } else if (Core.Bytes.check(v)) {
         return true;
-    } else {
-        $.racketCoreError(`isImmutable not implemented for ${v}`);
     }
+    $.racketCoreError(`isImmutable not implemented for ${v}`);
 }
 
 /* --------------------------------------------------------------------------*/
 // String construction and manipulation
 
 export function format(pattern, ...args) {
-    //TODO: Only ~a and ~x are supported
-    var matched = 0;
-    return Core.UString.makeMutable(
-        pattern.toString().replace(/~[axs]/g, function (match) {
-            if (matched >= args.length) {
-                throw Core.racketContractError("insufficient pattern arguments");
+    // TODO: Only ~a and ~x are supported
+    let matched = 0;
+    return Core.UString.makeMutable(pattern.toString().replace(/~[axs]/g, (match) => {
+        if (matched >= args.length) {
+            throw Core.racketContractError('insufficient pattern arguments');
+        }
+        switch (match[1]) {
+        case 'a': return args[matched++];
+        case 'x': return args[matched++].toString(16);
+        case 's': return ((v) => {
+            // TODO: This is very broken, fix it (likely needs a new Primitive method).
+            if (typeof v === 'number') {
+                return v.toString();
             }
-            switch (match[1]) {
-                case 'a': return args[matched++];
-                case 'x': return args[matched++].toString(16);
-                case 's': return ((v) => {
-                    // TODO: This is very broken, fix it (likely needs a new Primitive method).
-                    if (typeof v === 'number') {
-                        return v.toString();
-                    } else {
-                        return JSON.stringify(v.toString());
-                    }
-                })(args[matched++]);
-            }
-        }));
+            return JSON.stringify(v.toString());
+        })(args[matched++]);
+        }
+    }));
 }
 
 export function listToString(lst) {
-    return Core.UString.makeMutableFromChars(
-        Core.Pair.listToArray(lst));
+    return Core.UString.makeMutableFromChars(Core.Pair.listToArray(lst));
 }
 
 /* --------------------------------------------------------------------------*/
@@ -58,7 +54,6 @@ export function print(v, out) {
 }
 
 
-
 /* --------------------------------------------------------------------------*/
 // Errors
 
@@ -66,12 +61,11 @@ export function error(...args) {
     if (args.length === 1 && Core.Symbol.check(args[0])) {
         throw Core.racketCoreError(args[0].toString());
     } else if (args.length > 0 && typeof args[0] === 'string') {
-        throw Core.racketCoreError(args.map((v) => v.toString()).join(" "));
+        throw Core.racketCoreError(args.map(v => v.toString()).join(' '));
     } else if (args.length > 0 && Core.Symbol.check(args[0])) {
-        throw Core.racketCoreError(
-            format(`${args[0].toString()}: ${args[1]}`, ...args.slice(2)));
+        throw Core.racketCoreError(format(`${args[0].toString()}: ${args[1]}`, ...args.slice(2)));
     } else {
-        throw Core.racketContractError("error: invalid arguments");
+        throw Core.racketContractError('error: invalid arguments');
     }
 }
 
@@ -80,21 +74,21 @@ export function error(...args) {
 
 export function random(...args) {
     switch (args.length) {
-        case 0: return Math.random();
-        case 1:
-            if (args[0] > 0) {
-                return Math.floor(Math.random() * args[0]);
-            } else {
-                error("random: argument should be positive");
-            }
-        case 2:
-            if (args[0] > 0 && args[1] > args[0]) {
-                return Math.floor(args[0] + Math.random() * (args[1] - args[0]));
-            } else {
-                error("random: invalid arguments");
-            }
-        default:
-            error("random: invalid number of arguments")
+    case 0: return Math.random();
+    case 1:
+        if (args[0] > 0) {
+            return Math.floor(Math.random() * args[0]);
+        }
+        error('random: argument should be positive');
+
+    case 2:
+        if (args[0] > 0 && args[1] > args[0]) {
+            return Math.floor(args[0] + Math.random() * (args[1] - args[0]));
+        }
+        error('random: invalid arguments');
+
+    default:
+        error('random: invalid number of arguments');
     }
 }
 
@@ -148,17 +142,16 @@ export function findf(f, lst) {
 // TODO: more faithfully reproduce Racket sort?
 // this implements raw-sort from #%kernel, see racket/private/list
 export function sort9(lst, cmp) {
-    var arr = Core.Pair.listToArray(lst);
-    var x2i = new Map();
-    arr.forEach(function (x, i) { x2i.set(x, i); });
-    var srted = arr.sort(function (x, y) {
+    const arr = Core.Pair.listToArray(lst);
+    const x2i = new Map();
+    arr.forEach((x, i) => { x2i.set(x, i); });
+    const srted = arr.sort((x, y) => {
         if (cmp(x, y)) {
             return -1;
         } else if (cmp(y, x)) {
             return 1;
-        } else { // x = y, simulate stable sort by comparing indices
-            return x2i.get(x) - x2i.get(y);
-        }
+        } // x = y, simulate stable sort by comparing indices
+        return x2i.get(x) - x2i.get(y);
     });
 
     return Core.Pair.listFromArray(srted);


### PR DESCRIPTION
.eslintrc changes:

* Disallow dangling commas as they do not always work in NodeJS.
* Allow `~` by default as it is not likely to be a typo.
* Allow leading underscores by default when called via `this`, e.g.
  `this._private_prop`.
* Allow use-before-define for functions. It is safe as function
  declarations are hoisted, and we do it throughout the codebase.
* Allow generator loops (`for ... of`), as we do not target older
  browsers that do not support them (AirBnB bans them by default because
  the polyfill is too heavy).

There are still some lint errors but they will need to be fixed /
ignored manully.