### PR TITLE
internedMake: Use a Map instead of Object

### DIFF
--- a/racketscript-compiler/racketscript/compiler/runtime/core/lib.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/lib.js
@@ -79,14 +79,19 @@ export function attachReadOnlyProperty(o, k, v) {
     });
 }
 
+/**
+ * @param {function(String|UString.UString)} f
+ * @return {function(String)}
+ */
 export function internedMake(f) {
-    const cache = {};
+    const cache = new Map();
     return (v) => {
-        if (v in cache) {
-            return cache[v];
+        v = v.toString();
+        let result = cache.get(v);
+        if (result === undefined) {
+            result = f(v);
+            cache.set(v, result);
         }
-        const result = f(v);
-        cache[v] = result;
         return result;
     };
 }


### PR DESCRIPTION
Using objects as maps is dangerous and leads to hard-to-debug cases.
E.g. consider what happens if someone puts `"hasOwnProperty"` as a key.

Actual `Map`s are also slightly faster in most modern browsers.