### PR TITLE
Fix TextEncoder/Decoder in browsers

### DIFF
--- a/racketscript-compiler/racketscript/compiler/runtime/core/box.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/box.js
@@ -1,5 +1,6 @@
 import { Primitive } from './primitive.js';
 import { isEqual } from './equality.js';
+import { hashForEqual } from './hashing.js';
 
 class Box extends Primitive {
     constructor(v) {

--- a/racketscript-compiler/racketscript/compiler/runtime/core/bytes.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/bytes.js
@@ -1,9 +1,9 @@
 import { hashIntArray } from './raw_hashing.js';
 
 // In node.js, TextDecoder is not global and needs to be imported.
-if (typeof TextDecoder === 'undefined') {
-    var TextDecoder = require('util').TextDecoder;
-}
+const TextDecoder = (typeof window === 'undefined')
+    ? require('util').TextDecoder
+    : window.TextDecoder; // eslint-disable-line no-undef
 
 /**
  * @param {*} bs

--- a/racketscript-compiler/racketscript/compiler/runtime/core/unicode_string.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/unicode_string.js
@@ -7,9 +7,9 @@ import { internedMake } from './lib.js';
 import { hashIntArray } from './raw_hashing.js';
 
 // In node.js, TextEncoder is not global and needs to be imported.
-if (typeof TextEncoder === 'undefined') {
-    var TextEncoder = require('util').TextEncoder;
-}
+const TextEncoder = (typeof window === 'undefined')
+    ? require('util').TextEncoder
+    : window.TextEncoder; // eslint-disable-line no-undef
 
 /**
  * A sequence of {Char.Char}s.


### PR DESCRIPTION
Fixes a bug introduced in #115.
`var` got hoisted even if the `if` check failed, resulting in undefined TextEncoder/Decoder.

Also fixes a missing import in box.js.