### PR TITLE
Fix parameterize to false'ish values.

### DIFF
--- a/racketscript-compiler/racketscript/compiler/runtime/paramz.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/paramz.js
@@ -37,7 +37,8 @@ export function makeParameter(initValue) {
     const param = function (maybeSetVal) {
         // Get current value box from parameterization. The function
         // `param` that we result is the key.
-        let pv = getCurrentParameterization().get(param, false) ||
+        const current = getCurrentParameterization();
+        let pv = (current && current.get(param, false)) ||
             __top.get(param, false);
         // Create entry in __top if its a mutation.
         if (!pv && maybeSetVal !== undefined) {
@@ -46,7 +47,7 @@ export function makeParameter(initValue) {
         }
         // Get/Set
         if (maybeSetVal === undefined) {
-            return (pv && pv.get()) || initValue;
+            return pv ? pv.get() : initValue;
         }
         pv.set(maybeSetVal);
     };

--- a/tests/wcm/parameter-set.rkt
+++ b/tests/wcm/parameter-set.rkt
@@ -16,4 +16,11 @@
     (set! p2 p2*)
     (displayln (list (p1) (p2)))))
 
+(define falsy-param (make-parameter #t))
+(displayln (falsy-param))
+(parameterize ([falsy-param #f])
+  (displayln (falsy-param)))
+(parameterize ([falsy-param 0])
+  (displayln (falsy-param)))
+
 (displayln (list (p1) (p2)))


### PR DESCRIPTION
The previous version made it impossible to parameterize to false, 0, etc.

Also adds handling for `getCurrentParametrization()` returning false.