### PR TITLE
Printing and formatting

### DIFF
--- a/racketscript-compiler/racketscript/compiler/runtime/core.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core.js
@@ -40,15 +40,14 @@ export {
 };
 
 export {
-    toString,
-    format,
-
     argumentsToArray,
-    argumentsSlice,
+    argumentsSlice
+} from './core/lib.js';
 
+export {
     racketCoreError,
     racketContractError
-} from './core/lib.js';
+} from './core/errors.js';
 
 export {
     attachProcedureArity
@@ -65,6 +64,12 @@ export {
     hashForEqv,
     hashForEqual
 } from './core/hashing.js';
+
+export {
+    display,
+    write,
+    print
+} from './core/printing.js';
 
 // ;-----------------------------------------------------------------------------
 

--- a/racketscript-compiler/racketscript/compiler/runtime/core/box.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/box.js
@@ -1,19 +1,16 @@
-import { Primitive } from './primitive.js';
+import { PrintablePrimitive } from './printable_primitive.js';
 import { isEqual } from './equality.js';
 import { hashForEqual } from './hashing.js';
+import { displayNativeString, writeNativeString } from './print_native_string.js';
+import { displayUString, writeUString } from './print_ustring.js';
+import * as UString from './unicode_string.js';
 
-class Box extends Primitive {
+const BOX_PREFIX_USTRING = UString.makeInternedImmutable('#&');
+
+class Box extends PrintablePrimitive {
     constructor(v) {
         super();
         this.value = v;
-    }
-
-    toString() {
-        return this.value;
-    }
-
-    toRawString() {
-        return this.toString();
     }
 
     set(v) {
@@ -37,6 +34,38 @@ class Box extends Primitive {
      */
     hashForEqual() {
         return hashForEqual(this.value);
+    }
+
+    /**
+     * @param {!Ports.NativeStringOutputPort} out
+     */
+    displayNativeString(out) {
+        out.consume('#&');
+        displayNativeString(out, this.value);
+    }
+
+    /**
+     * @param {!Ports.UStringOutputPort} out
+     */
+    displayUString(out) {
+        out.consume(BOX_PREFIX_USTRING);
+        displayUString(out, this.value);
+    }
+
+    /**
+     * @param {!Ports.NativeStringOutputPort} out
+     */
+    writeNativeString(out) {
+        out.consume('#&');
+        writeNativeString(out, this.value);
+    }
+
+    /**
+     * @param {!Ports.UStringOutputPort} out
+     */
+    writeUString(out) {
+        out.consume(BOX_PREFIX_USTRING);
+        writeUString(out, this.value);
     }
 }
 

--- a/racketscript-compiler/racketscript/compiler/runtime/core/bytes.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/bytes.js
@@ -48,6 +48,16 @@ export function toString(bytes) {
 }
 
 /**
+ * Writes a string representation similar to Racket's `display` to the given port.
+ *
+ * @param {!Ports.NativeStringOutputPort} out
+ * @param {!Uint8Array} bytes
+ */
+export function displayNativeString(out, bytes) {
+    out.consume(toString(bytes));
+}
+
+/**
  * @param {!Uint8Array} bytes
  * @return {!number} a 32-bit integer
  */

--- a/racketscript-compiler/racketscript/compiler/runtime/core/char.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/char.js
@@ -13,7 +13,7 @@ import { Primitive } from './primitive.js';
  * @property {!number} codepoint
  * @final
  */
-export class Char extends Primitive {
+export class Char extends Primitive /* implements Printable */ {
     /**
      * @param {!number} codepoint a non-negative integer.
      * @param {(!string|null)} nativeString
@@ -60,19 +60,80 @@ export class Char extends Primitive {
     }
 
     /**
-     * @return {!String}
-     * @override
-     */
-    toRawString() {
-        return `#\\u${this.codepoint}`;
-    }
-
-    /**
      * @return {!number} a non-negative integer.
      * @override
      */
     hashForEqual() {
         return this.codepoint;
+    }
+
+    /**
+     * @param {!Ports.NativeStringOutputPort} out
+     */
+    displayNativeString(out) {
+        out.consume(this.toString());
+    }
+
+    /**
+     * @param {!Ports.NativeStringOutputPort} out
+     */
+    writeNativeString(out) {
+        const c = this.codepoint;
+        switch (c) {
+        // Reference implementation:
+        // https://github.com/racket/racket/blob/cbfcc904ab621a338627e77d8f5a34f930ead0ab/racket/src/racket/src/print.c#L4089
+        case 0:
+            out.consume('#\\nul');
+            break;
+        case 8:
+            out.consume('#\\backspace');
+            break;
+        case 9:
+            out.consume('#\\tab');
+            break;
+        case 10:
+            out.consume('#\\newline');
+            break;
+        case 11:
+            out.consume('#\\vtab');
+            break;
+        case 12:
+            out.consume('#\\page');
+            break;
+        case 13:
+            out.consume('#\\return');
+            break;
+        case 32:
+            out.consume('#\\space');
+            break;
+        case 127:
+            out.consume('#\\rubout');
+            break;
+        default:
+            if (isGraphicCodepoint(c)) {
+                out.consume(`#\\${this.toString()}`);
+            } else {
+                out.consume(c > 0xFFFF
+                    ? `#\\U${c.toString(16).toUpperCase().padStart(8, '0')}`
+                    : `#\\u${c.toString(16).toUpperCase().padStart(4, '0')}`);
+            }
+        }
+    }
+
+    /**
+     * @param {!Ports.NativeStringOutputPort} out
+     */
+    printNativeString(out) {
+        this.writeNativeString(out);
+    }
+
+    // displayUstring is defined in unicode_string.js to avoid a circular dependency.
+
+    /**
+     * @param {!Ports.UStringOutputPort} out
+     */
+    printUString(out) {
+        this.writeUString(out);
     }
 }
 
@@ -118,7 +179,8 @@ export function charFromNativeString(s) {
 export function check(char) {
     // Because Char is final, we can compare the constructor directly
     // instead of using the much slower `instanceof` operator.
-    return char.constructor === Char;
+    return typeof char === 'object' && char !== null &&
+        char.constructor === Char;
 }
 
 /**
@@ -164,4 +226,64 @@ export function charUtf8Length(c) {
         return 5;
     }
     return 6;
+}
+
+// The Unicode property testing methods below were generated with:
+// https://gist.github.com/glebm/2749c75b4fc4fed4dc5911925bb8f8b9
+
+/**
+ * A graphic codepoint in Racket is in one the following General Categories:
+ *
+ *   Letter, Mark, Number, Punctuation, Symbol.
+ *
+ * WARNING: This method currently always returns `false` for codepoints >= 2048,
+ * even if they are graphic.
+ *
+ * @param {!number} c a Unicode codepoint
+ * @return {!boolean} Whether the codepoint is graphic
+ * @api private
+ */
+export function isGraphicCodepoint(c) {
+    // This is just a quick hack to have sensible output in European locales.
+    // TODO: If we implement Unicode property testing, use it here instead.
+    /* eslint-disable no-mixed-operators */
+    return (
+        c > 32 && c < 127 ||
+        (c > 160 && c < 896 && !(c === 173 || c > 887 && c < 890)) ||
+        (c > 899 && c < 1480 && !(c === 1328 || c > 1366 && c < 1369 ||
+            c === 1376 || c === 1416 || c > 1418 && c < 1421 || c === 1424 ||
+            (c > 906 && c < 910 && c !== 908) || c === 930)) ||
+        c > 1487 && c < 1515 || c > 1519 && c < 1525 ||
+        (c > 1541 && c < 1970 && !(c > 1563 && c < 1566 || c === 1757 ||
+            c > 1805 && c < 1808 || c > 1866 && c < 1869)) ||
+        c > 1983 && c < 2043);
+    /* eslint-enable no-mixed-operators */
+}
+
+/**
+ * @param {!number} c a Unicode codepoint
+ * @return {!boolean} Whether the codepoint's Unicode general category
+ * is "Zs" ("Space_Separator") or if char is #\tab.
+ * @api private
+ */
+export function isBlankCodepoint(c) {
+    /* eslint-disable no-mixed-operators */
+    return (
+        c === 9 || c === 32 || c === 160 || c === 5760 ||
+        c > 8191 && c < 8203 || c === 8239 || c === 8287 || c === 12288);
+    /* eslint-enable no-mixed-operators */
+}
+
+/**
+ * @param {!number} c a Unicode codepoint
+ * @return {!boolean} Whether the codepoint has the Unicode "White_Space" property.
+ * @api private
+ */
+export function isWhitespaceCodepoint(c) {
+    /* eslint-disable no-mixed-operators */
+    return (
+        c > 8 && c < 14 || c === 32 || c === 133 || c === 160 || c === 5760 ||
+        c > 8191 && c < 8203 || c > 8231 && c < 8234 || c === 8239 ||
+        c === 8287 || c === 12288);
+    /* eslint-enable no-mixed-operators */
 }

--- a/racketscript-compiler/racketscript/compiler/runtime/core/errors.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/errors.js
@@ -1,0 +1,43 @@
+import { MiniNativeOutputStringPort } from './mini_native_output_string_port.js';
+import { printNativeString } from './print_native_string.js';
+
+function printError(out, msg, args) {
+    out.consume(msg);
+    for (const arg of args) {
+        out.consume(' ');
+        if (typeof arg === 'string') {
+            out.consume(arg);
+        } else {
+            printNativeString(out, arg, /* printAsExpression */ true, /* quoteDepth */ 0);
+        }
+    }
+}
+
+function makeError(name) {
+    /**
+     * The "(error msg v ...)" form.
+     * Besides Racket values, also allows native strings.
+     */
+    const e = function (msg, ...args) {
+        this.name = name;
+
+        const stringOut = new MiniNativeOutputStringPort();
+        printError(stringOut, msg, args);
+        this.message = stringOut.getOutputString();
+
+        this.stack = (new Error()).stack;
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, this.constructor);
+        } else {
+            this.stack = (new Error()).stack;
+        }
+    };
+    e.prototype = Object.create(Error.prototype);
+    e.prototype.constructor = e;
+
+    return (...args) =>
+        new (Function.prototype.bind.apply(e, [this].concat(args)))();
+}
+
+export const racketCoreError = makeError('RacketCoreError');
+export const racketContractError = makeError('RacketContractError');

--- a/racketscript-compiler/racketscript/compiler/runtime/core/keyword.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/keyword.js
@@ -1,18 +1,18 @@
-import { Primitive } from './primitive.js';
+import { PrintablePrimitive } from './printable_primitive.js';
 import { internedMake } from './lib.js';
 
-class Keyword extends Primitive {
+class Keyword extends PrintablePrimitive {
     constructor(v) {
         super();
         this.v = v;
     }
 
-    toString() {
-        return this.v;
-    }
-
-    toRawString() {
-        return `'${this.v}`;
+    /**
+     * @param {!Ports.NativeStringOutputPort} out
+     */
+    displayNativeString(out) {
+        out.consume('#:');
+        out.consume(this.v);
     }
 
     equals(v) {

--- a/racketscript-compiler/racketscript/compiler/runtime/core/lib.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/lib.js
@@ -1,59 +1,5 @@
 export { hamt } from '../third-party/hamt.js';
 
-// Because we don't have a wrapper type for bytes,
-// we depend on it here for type-checking and toString conversion.
-// TODO: extract toString to a separate file.
-import * as Bytes from './bytes.js';
-
-/* --------------------------------------------------------------------------*/
-/* Strings */
-
-/**
- * @param {*} v
- * @return {!String}
- */
-export function toString(v) {
-    if (v === true) return '#t';
-    if (v === false) return '#f';
-    if (v === undefined || v === null) return '#<void>';
-    if (Bytes.check(v)) return Bytes.toString(v);
-    return v.toString();
-}
-
-export function format1(pattern, args) {
-    return pattern.toString().replace(/{(\d+)}/g, (match, number) => (typeof args[number] !== 'undefined'
-        ? args[number]
-        : match));
-}
-
-export function format(pattern, ...args) {
-    return format1(pattern, args);
-}
-
-/* --------------------------------------------------------------------------*/
-/* Errors */
-
-function makeError(name) {
-    const e = function (pattern, ...args) {
-        this.name = name;
-        this.message = format1(pattern, args);
-        this.stack = (new Error()).stack;
-        if (Error.captureStackTrace) {
-            Error.captureStackTrace(this, this.constructor);
-        } else {
-            this.stack = (new Error()).stack;
-        }
-    };
-    e.prototype = Object.create(Error.prototype);
-    e.prototype.constructor = e;
-
-    return (...args) =>
-        new (Function.prototype.bind.apply(e, [this].concat(args)))();
-}
-
-export const racketCoreError = makeError('RacketCoreError');
-export const racketContractError = makeError('RacketContractError');
-
 /* --------------------------------------------------------------------------*/
 /* Other Helpers */
 

--- a/racketscript-compiler/racketscript/compiler/runtime/core/marks.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/marks.js
@@ -1,7 +1,7 @@
 // Continuation Marks
 import * as Pair from './pair.js';
 import * as Symbol from './symbol.js';
-import * as $ from './lib.js';
+import { racketCoreError } from './errors.js';
 import { hashForEq as HASH } from './hashing.js';
 
 let __frames;
@@ -69,7 +69,7 @@ function savePrompt(promptTag) {
 function deleteCurrentPrompt(promptTag) {
     const promptVal = __prompts.get(promptTag);
     if (promptVal === undefined) {
-        throw $.racketCoreError('No corresponding tag in continuation!');
+        throw racketCoreError('No corresponding tag in continuation!');
     }
     promptVal.pop();
     if (promptVal.length === 0) {
@@ -139,7 +139,7 @@ export function getContinuationMarks(promptTag) {
     const promptFrame = getPromptFrame(promptTag);
     if (promptFrame === undefined &&
         promptTag !== __defaultContinuationPromptTag) {
-        throw $.racketCoreError('No corresponding tag in continuation!');
+        throw racketCoreError('No corresponding tag in continuation!');
     }
 
     const result = [];

--- a/racketscript-compiler/racketscript/compiler/runtime/core/mini_native_output_string_port.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/mini_native_output_string_port.js
@@ -1,0 +1,26 @@
+/**
+ * A simplified internal-only version of Ports.NativeOutputStringPort.
+ *
+ * This can be used where dependency on Ports is not possible,
+ * e.g. because Ports are Printable,
+ * and provides a faster no-frills internal implementation.
+ */
+export class MiniNativeOutputStringPort {
+    constructor() {
+        this._buffer = [];
+    }
+
+    /**
+     * @param {String} nativeString
+     */
+    consume(nativeString) {
+        this._buffer.push(nativeString);
+    }
+
+    /**
+     * @return {String} nativeString
+     */
+    getOutputString() {
+        return this._buffer.join('');
+    }
+}

--- a/racketscript-compiler/racketscript/compiler/runtime/core/mpair.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/mpair.js
@@ -1,9 +1,9 @@
-import { Primitive } from './primitive.js';
+import { PrintablePrimitive } from './printable_primitive.js';
+import { displayNativeString, writeNativeString } from './print_native_string.js';
 import { isEqual } from './equality.js';
-import * as $ from './lib.js';
 import { EMPTY, isEmpty, isList } from './pair.js';
 
-class MPair extends Primitive {
+class MPair extends PrintablePrimitive {
     /** @private */
     constructor(hd, tl) {
         super();
@@ -13,29 +13,43 @@ class MPair extends Primitive {
         this._cachedHashCode = null;
     }
 
-    toString() {
-        const result = ['('];
+    /**
+     * @param {!Ports.NativeStringOutputPort} out
+     * @param {function(Ports.NativeStringOutputPort, *)} itemFn
+     */
+    writeToPort(out, itemFn) {
+        out.consume('(');
         let rest = this;
         while (true) {
             if (check(rest)) {
-                result.push($.toString(rest.hd));
+                itemFn(out, rest.hd);
             } else {
-                result.push('. ', $.toString(rest));
+                out.consume('. ');
+                itemFn(out, rest);
                 break;
             }
             rest = rest.tl;
             if (isEmpty(rest)) {
                 break;
             } else {
-                result.push(' ');
+                out.consume(' ');
             }
         }
-        result.push(')');
-        return result.join('');
+        out.consume(')');
     }
 
-    toRawString() {
-        return `'${this.toString()}`;
+    /**
+     * @param {!Ports.NativeStringOutputPort} out
+     */
+    displayNativeString(out) {
+        this.writeToPort(out, displayNativeString);
+    }
+
+    /**
+     * @param {!Ports.NativeStringOutputPort} out
+     */
+    writeNativeString(out) {
+        this.writeToPort(out, writeNativeString);
     }
 
     equals(v) {

--- a/racketscript-compiler/racketscript/compiler/runtime/core/numbers.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/numbers.js
@@ -1,4 +1,4 @@
-import * as $ from './lib.js';
+import { racketCoreError } from './errors.js';
 
 /* Arithmetic */
 
@@ -36,7 +36,7 @@ export function div(...operands) {
 
 export function compare(cmp, operands) {
     if (operands.length < 2) {
-        throw $.racketCoreError('compare {0}', 'atleast 2 arguments required');
+        throw racketCoreError('compare: at least 2 arguments required, given', ...operands);
     }
     for (let i = 1; i < operands.length; i++) {
         if (!cmp(operands[i - 1], operands[i])) {

--- a/racketscript-compiler/racketscript/compiler/runtime/core/primitive.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/primitive.js
@@ -1,4 +1,3 @@
-import * as $ from './lib.js';
 import { hashString } from './raw_hashing.js';
 
 /**
@@ -6,62 +5,21 @@ import { hashString } from './raw_hashing.js';
  * such as structs, pairs, values, ...
  *
  * Subclasses must override the following methods:
- * * toString
- * * toRawString
+ * * displayNativeString
  * * isImmutable
  * * equals
  *
  * @abstract
  */
 export class Primitive {
-    constructor() {
-        // Abstract base class
-        // if (new.target === Primitive) {
-        //     throw new TypeError("Cannot construct Abstract instances directly");
-        // }
-    }
-
-    /**
-     * @return {!String} The string representation matching Racket's `display`.
-     */
-    toString() {
-        throw $.racketCoreError('Not Implemented');
-    }
-
-    /**
-     * @return {!String} The deserializble string representation matching Racket's `write`.
-     */
-    toRawString() {
-        return this.toString();
-    }
-
-    isImmutable() {
-        throw $.racketCoreError('Not Implemented');
-    }
-
-    /**
-     * @param {*} v
-     * @return {!boolean}
-     */
-    equals(v) {
-        throw $.racketCoreError('Not Implemented {0}', v);
-    }
+    /** @abstract isImmutable(): boolean; */
+    /** @abstract equals(*): boolean; */
 
     /**
      * @return {!number} a 32-bit integer
      */
     hashForEqual() {
-        return hashString(this.toRawString());
-    }
-
-    /**
-     * This should either return {this} or a value which has
-     * a partial order in JavaScript.
-     *
-     * @return {!(Primitive|number|string|boolean)}
-     */
-    valueOf() {
-        return this;
+        return hashString(this.toString());
     }
 }
 

--- a/racketscript-compiler/racketscript/compiler/runtime/core/print_native_string.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/print_native_string.js
@@ -1,0 +1,54 @@
+import * as Primitive from './primitive.js';
+import * as Bytes from './bytes.js';
+import * as Procedure from './procedure.js';
+
+/**
+ * @param {!Ports.NativeStringOutputPort} out
+ * @param {!(Primitive.Primitive|Uint8Array|Function|String|number|boolean|undefined|null)} v
+ */
+export function displayNativeString(out, v) {
+    if (v === true) {
+        out.consume('#t');
+    } else if (v === false) {
+        out.consume('#f');
+    } else if (v === undefined || v === null) {
+        out.consume('#<void>');
+    } else if (Primitive.check(v)) {
+        v.displayNativeString(out);
+    } else if (Bytes.check(v)) {
+        Bytes.displayNativeString(out, v);
+    } else if (Procedure.check(v)) {
+        Procedure.displayNativeString(out, v);
+    } else /* if (typeof v === 'number' || typeof v === 'string') */ {
+        out.consume(v.toString());
+    }
+}
+
+/**
+ * @param {!Ports.NativeStringOutputPort} out
+ * @param {!(Primitive.Primitive|Uint8Array|Function|String|number|boolean|undefined|null)} v
+ */
+export function writeNativeString(out, v) {
+    if (Primitive.check(v)) {
+        // Assume `v` implements Printable, as only Values does not,
+        // and it cannot be passed here.
+        v.writeNativeString(out);
+    } else {
+        displayNativeString(out, v);
+    }
+}
+
+
+/**
+ * @param {!Ports.NativeStringOutputPort} out
+ * @param {!(Primitive.Primitive|Uint8Array|Function|String|number|boolean|undefined|null)} v
+ * @param {!boolean} printAsExpression
+ * @param {!(0|1)} quoteDepth
+ */
+export function printNativeString(out, v, printAsExpression, quoteDepth) {
+    if (printAsExpression && quoteDepth !== 1 && Primitive.check(v)) {
+        v.printNativeString(out);
+    } else {
+        writeNativeString(out, v);
+    }
+}

--- a/racketscript-compiler/racketscript/compiler/runtime/core/print_ustring.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/print_ustring.js
@@ -1,0 +1,60 @@
+import * as Primitive from './primitive.js';
+import * as Bytes from './bytes.js';
+import * as Procedure from './procedure.js';
+import * as UString from './unicode_string.js';
+
+const TRUE_USTRING = UString.makeInternedImmutable('#t');
+const FALSE_USTRING = UString.makeInternedImmutable('#f');
+const VOID_USTRING = UString.makeInternedImmutable('#<void>');
+
+/**
+ * @param {!Ports.UStringOutputPort} out
+ * @param {!(Primitive.Primitive|Uint8Array|Function|String|number|boolean|undefined|null)} v
+ */
+export function displayUString(out, v) {
+    if (v === true) {
+        out.consume(TRUE_USTRING);
+    } else if (v === false) {
+        out.consume(FALSE_USTRING);
+    } else if (v === undefined || v === null) {
+        out.consume(VOID_USTRING);
+    } else if (typeof v === 'number' || typeof v === 'string') {
+        out.consume(UString.makeMutable(v.toString()));
+    } else if (Primitive.check(v)) {
+        v.displayUString(out);
+    } else if (Bytes.check(v)) {
+        out.consume(UString.makeMutable(Bytes.toString(v)));
+    } else if (Procedure.check(v)) {
+        out.consume(UString.makeMutable(Procedure.toString(v)));
+    } else /* if (typeof v === 'number' || typeof v === 'string') */ {
+        out.consume(UString.makeMutable(v.toString()));
+    }
+}
+
+/**
+ * @param {!Ports.UStringOutputPort} out
+ * @param {!(Primitive.Primitive|Uint8Array|Function|String|number|boolean|undefined|null)} v
+ */
+export function writeUString(out, v) {
+    if (Primitive.check(v)) {
+        // Assume `v` implements Printable, as only Values does not,
+        // and it cannot be passed here.
+        v.writeUString(out);
+    } else {
+        displayUString(out, v);
+    }
+}
+
+/**
+ * @param {!Ports.UStringOutputPort} out
+ * @param {!(Primitive.Primitive|Uint8Array|Function|String|number|boolean|undefined|null)} v
+ * @param {!boolean} printAsExpression
+ * @param {!(0|1)} quoteDepth
+ */
+export function printUString(out, v, printAsExpression, quoteDepth) {
+    if (printAsExpression && quoteDepth !== 1 && Primitive.check(v)) {
+        v.printUString(out);
+    } else {
+        writeUString(out, v);
+    }
+}

--- a/racketscript-compiler/racketscript/compiler/runtime/core/printable_primitive.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/printable_primitive.js
@@ -1,0 +1,76 @@
+// PrintablePrimitive subclass avoids circular dependency with UString and Ports.
+
+import { Primitive } from './primitive.js';
+import { MiniNativeOutputStringPort } from './mini_native_output_string_port.js';
+import * as UString from './unicode_string.js';
+
+const PRINT_PREFIX_USTRING = UString.makeInternedImmutable("'");
+
+export class PrintablePrimitive extends Primitive /* implements Printable */ {
+    /**
+     * Writes a String representation similar to Racket's `display` to the given port.
+     *
+     * @param {!Ports.NativeStringOutputPort} out
+     */
+    /* abstract displayNativeString(out); */
+
+    /**
+     * Writes a UString representation similar to Racket's `display` to the given port.
+     *
+     * @param {!Ports.UStringOutputPort} out
+     */
+    displayUString(out) {
+        const stringOut = new MiniNativeOutputStringPort();
+        this.displayNativeString(stringOut);
+        out.consume(UString.makeMutable(stringOut.getOutputString()));
+    }
+
+    /**
+     * Writes a string representation that can be read by Racket's `read` to the given port.
+     *
+     * @param {!Ports.NativeStringOutputPort} out
+     */
+    writeNativeString(out) {
+        this.displayNativeString(out);
+    }
+
+    /**
+     * Writes a UString representation that can be read by Racket's `read` to the given port.
+     *
+     * @param {!Ports.UStringOutputPort} out
+     */
+    writeUString(out) {
+        const stringOut = new MiniNativeOutputStringPort();
+        this.writeNativeString(stringOut);
+        out.consume(UString.makeMutable(stringOut.getOutputString()));
+    }
+
+    /**
+     * Writes a string representation similar to Racket's `print` to the given port.
+     *
+     * @param {!Ports.NativeStringOutputPort} out
+     */
+    printNativeString(out) {
+        out.consume("'");
+        this.writeNativeString(out);
+    }
+
+    /**
+     * Writes a UString representation similar to Racket's `print` to the given port.
+     *
+     * @param {!Ports.UStringOutputPort} out
+     */
+    printUString(out) {
+        out.consume(PRINT_PREFIX_USTRING);
+        this.writeUString(out);
+    }
+
+    /**
+     * @return {!String} a string representation similar to Racket's `display`.
+     */
+    toString() {
+        const out = new MiniNativeOutputStringPort();
+        this.displayNativeString(out);
+        return out.getOutputString();
+    }
+}

--- a/racketscript-compiler/racketscript/compiler/runtime/core/printing.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/printing.js
@@ -1,0 +1,50 @@
+import * as Primitive from './primitive.js';
+import { displayNativeString, writeNativeString, printNativeString } from './print_native_string.js';
+import { displayUString, writeUString, printUString } from './print_ustring.js';
+import * as Ports from './ports.js';
+
+// TODO: All of these functions can be migrated to kernel.rkt after fprintf is.
+
+/**
+ * Writes a string representation similar to Racket's `display` to the given port.
+ *
+ * @param {(!Ports.NativeStringOutputPort|!Ports.UStringOutputPort)} out
+ * @param {!(Primitive.Primitive|Uint8Array|Function|String|number|boolean|undefined|null)} v
+ */
+export function display(out, v) {
+    if (out.isUStringPort()) {
+        displayUString(out, v);
+    } else {
+        displayNativeString(out, v);
+    }
+}
+
+/**
+ * Writes a string representation that can be read by Racket's `read` to the given port.
+ *
+ * @param {!Ports.NativeStringOutputPort} out
+ * @param {!(Primitive.Primitive|Uint8Array|Function|String|number|boolean|undefined|null)} v
+ */
+export function write(out, v) {
+    if (out.isUStringPort()) {
+        writeUString(out, v);
+    } else {
+        writeNativeString(out, v);
+    }
+}
+
+/**
+ * Writes a string representation similar to Racket's `print` to the given port.
+ *
+ * @param {!Ports.NativeStringOutputPort} out
+ * @param {!(Primitive.Primitive|Uint8Array|Function|String|number|boolean|undefined|null)} v
+ * @param {!boolean} printAsExpression
+ * @param {!(0|1)} quoteDepth
+ */
+export function print(out, v, printAsExpression, quoteDepth) {
+    if (out.isUStringPort()) {
+        printUString(out, v, printAsExpression, quoteDepth);
+    } else {
+        printNativeString(out, v, printAsExpression, quoteDepth);
+    }
+}

--- a/racketscript-compiler/racketscript/compiler/runtime/core/procedure.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/procedure.js
@@ -22,3 +22,13 @@ export function check(v) {
 export function toString(f) {
     return f.name ? `#<procedure:${f.name}>` : '#<procedure>';
 }
+
+/**
+ * Writes a string representation similar to Racket's `display` to the given port.
+ *
+ * @param {!Ports.NativeStringOutputPort} out
+ * @param {!Function} f
+ */
+export function displayNativeString(out, f) {
+    out.consume(toString(f));
+}

--- a/racketscript-compiler/racketscript/compiler/runtime/core/regexp.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/regexp.js
@@ -1,7 +1,7 @@
 import * as Bytes from './bytes.js';
 import * as UString from './unicode_string.js';
 import * as Pair from './pair.js';
-import * as $ from './lib.js';
+import { racketContractError } from './errors.js';
 
 /**
  * @param {*} v
@@ -35,7 +35,8 @@ export function match(pattern, input) {
 
     if (!(isRegexpPattern || isBytesPattern || isStringPattern)
         || !(isBytesInput || isStringInput)) {
-        throw $.racketContractError('expected regexp, string or byte pat, and string or byte input');
+        throw racketContractError('expected regexp, string or byte pat, ' +
+            'and string or byte input, got pattern:', pattern, ', input:', input);
     }
 
     /** @type {!UString.UString} */

--- a/racketscript-compiler/racketscript/compiler/runtime/core/symbol.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/symbol.js
@@ -1,19 +1,18 @@
-import { Primitive } from './primitive.js';
+import { PrintablePrimitive } from './printable_primitive.js';
 import { internedMake } from './lib.js';
 
-class Symbol extends Primitive {
+class Symbol extends PrintablePrimitive {
     constructor(v) {
         super();
         this.v = v;
         this._cachedHashCode = null;
     }
 
-    toString() {
-        return this.v;
-    }
-
-    toRawString() {
-        return `'${this.v}`;
+    /**
+     * @param {!Ports.NativeStringOutputPort} out
+     */
+    displayNativeString(out) {
+        out.consume(this.v);
     }
 
     equals(v) {

--- a/racketscript-compiler/racketscript/compiler/runtime/core/values.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/values.js
@@ -1,18 +1,9 @@
 import { Primitive } from './primitive.js';
-import { racketCoreError } from './lib.js';
 
 class Values extends Primitive {
     constructor(vals) {
         super();
         this.v = vals;
-    }
-
-    toString() {
-        throw racketCoreError('Not Implemented');
-    }
-
-    toRawString() {
-        return this.toString();
     }
 
     getAt(i) {

--- a/racketscript-compiler/racketscript/compiler/runtime/lib.rkt
+++ b/racketscript-compiler/racketscript/compiler/runtime/lib.rkt
@@ -176,13 +176,10 @@
 ;; ----------------------------------------------------------------------------
 ;; Errors
 
-(define default-check-message "Expected: {0}, Given: {1}, At: {2}")
-
 (define-syntax-rule (type-check/raise type what)
   (unless (#js.type.check what)
-    (throw (#js.Core.racketContractError "expected a {0}, but given {1}"
-                                         type
-                                         what))))
+    (throw (#js.Core.racketContractError "expected a" type
+                                         ", but given" what))))
 
 (define-syntax (check/raise stx)
   (syntax-parse stx
@@ -195,10 +192,9 @@
     [(_ chkfn what expected at)
      #'(unless (chkfn what)
          (throw
-          (#js.Core.racketContractError default-check-message
-                                        expected
-                                        what
-                                        at)))]))
+          (#js.Core.racketContractError "Expected:" expected ", given:" what
+                                        ", at:" at)))]))
+
 
 (define-syntax-rule (check/or c1 ...)
   (λ (v)

--- a/tests/basic/bytes.rkt
+++ b/tests/basic/bytes.rkt
@@ -4,3 +4,7 @@
 (displayln (bytes=? #"abc" #"abc"))
 (displayln (bytes=? #"abc" #"abd"))
 (bytes? (void))
+
+;; TODO: Not implemented correctly yet.
+; (writeln #"abc")
+; (println #"abc")

--- a/tests/basic/char.rkt
+++ b/tests/basic/char.rkt
@@ -40,3 +40,10 @@
 
 (displayln (char-utf-8-length #\a))
 (displayln (char-utf-8-length #\🎂))
+
+(println #\a)
+(println #\tab)
+(println #\߆)
+
+; This test requires a full implementation of isGraphicCodepoint to pass.
+; (println #\🎂)

--- a/tests/basic/format.rkt
+++ b/tests/basic/format.rkt
@@ -1,8 +1,78 @@
 #lang racket/base
 
-(displayln (format "~a" 1))
-(displayln (format "~a" "1"))
-(displayln (format "~a" #\b))
 (displayln (format "~x" 1))
 (displayln (format "~x" 50))
+(displayln (format "~b" 37))
+(displayln (format "~o" 37))
+
+(displayln (format "~~"))
+(displayln (format "~n"))
+(displayln (format "~%"))
+
+(displayln (format "~    hello"))
+
+(displayln (format "~a" (void)))
+(displayln (format "~s" (void)))
+(displayln (format "~v" (void)))
+
+(displayln (format "~a" 'apple))
+(displayln (format "~s" 'apple))
+(displayln (format "~v" 'apple))
+
+(displayln (format "~a" '#:apple))
+(displayln (format "~s" '#:apple))
+(displayln (format "~v" '#:apple))
+
+(displayln (format "~a" #f))
+(displayln (format "~s" #f))
+(displayln (format "~v" #f))
+(displayln (format "~a" #t))
+(displayln (format "~s" #t))
+(displayln (format "~v" #t))
+
+(displayln (format "~a" 135))
+(displayln (format "~s" 135))
+(displayln (format "~v" 135))
+(displayln (format "~b" 135))
+(displayln (format "~o" 135))
+(displayln (format "~x" 135))
+
+(displayln (format "~a" #\b))
+(displayln (format "~s" #\b))
+(displayln (format "~v" #\b))
+(displayln (format "~a" #\tab))
+(displayln (format "~s" #\tab))
+(displayln (format "~v" #\tab))
+
+(displayln (format "~a" "hello\tworld"))
+(displayln (format "~s" "hello\tworld"))
+(displayln (format "~v" "hello\tworld"))
+
+(displayln (format "~a" (box "apple\tis a fruit")))
+(displayln (format "~s" (box "apple\tis a fruit")))
+(displayln (format "~v" (box "apple\tis a fruit")))
+
+(displayln (format "~a" '(135 #\b "hello\tworld" (335 #\tab "hello\tworld"))))
+(displayln (format "~s" '(135 #\b "hello\tworld" (335 #\tab "hello\tworld"))))
+(displayln (format "~v" '(135 #\b "hello\tworld" (335 #\tab "hello\tworld"))))
+
+; We are only checking the length of the output for hash,
+; because the order is not guaranteed (and in fact different).
+(displayln (string-length (format "~a" (hash "apple" 'red "banana" 'yellow))))
+(displayln (string-length (format "~s" (hash "apple" 'red "banana" 'yellow))))
+(displayln (string-length (format "~v" (hash "apple" 'red "banana" 'yellow))))
+
+(displayln (format "~a" (vector "a" "b" "c")))
+(displayln (format "~s" (vector "a" "b" "c")))
+(displayln (format "~v" (vector "a" "b" "c")))
+
+(displayln (format "~a" 'apple))
+(displayln (format "~s" 'apple))
+(displayln (format "~v" 'apple))
+
+(define fn (λ () (void)))
+(displayln (format "~a" fn))
+(displayln (format "~s" fn))
+(displayln (format "~v" fn))
+
 (displayln (format "~a is ~x in hex" "15" 15))

--- a/tests/basic/list.rkt
+++ b/tests/basic/list.rkt
@@ -22,3 +22,15 @@
 (pair? (cons 1 #\x))
 
 (immutable? '())
+
+(displayln (cons 1 #\x))
+(writeln (cons 1 #\x))
+(println (cons 1 #\x))
+
+(displayln '(1 2 3))
+(displayln '())
+(writeln '(1 2 3))
+(writeln '())
+(println '(1 2 3))
+(println '(1 2 3) (current-output-port) 1)
+(println '())

--- a/tests/basic/print.rkt
+++ b/tests/basic/print.rkt
@@ -1,0 +1,9 @@
+#lang racket/base
+
+(println '(1 2 3))
+(parameterize ([print-as-expression #f])
+  (println '(1 2 3)))
+(println '(1 2 3) (current-output-port) 1)
+
+((current-print) '(1 2 3))
+((current-print) (void))

--- a/tests/struct/make.rkt
+++ b/tests/struct/make.rkt
@@ -13,3 +13,13 @@
 (define pb (posn0 1 2))
 (equal? (posn0 1 2) pb)
 (displayln pb)
+(writeln pb)
+(println pb)
+
+(displayln (posn '(1 2) #\x))
+(writeln (posn '(1 2) #\x))
+(println (posn '(1 2) #\x))
+
+(displayln (posn0 '(1 2) #\x))
+(writeln (posn0 '(1 2) #\x))
+(println (posn0 '(1 2) #\x))

--- a/tests/struct/print.rkt
+++ b/tests/struct/print.rkt
@@ -1,0 +1,15 @@
+#lang racket/base
+
+(struct point (x y))
+(displayln (point 1 '(#\a #\b)))
+(writeln (point 1 '(#\a #\b)))
+(println (point 1 '(#\a #\b)))
+(parameterize ([print-as-expression #f])
+  (println (point 1 '(#\a #\b))))
+
+(struct tpoint (x y) #:transparent)
+(displayln (tpoint 1 '(#\a #\b)))
+(writeln (tpoint 1 '(#\a #\b)))
+(println (tpoint 1 '(#\a #\b)))
+(parameterize ([print-as-expression #f])
+  (println (tpoint 1 '(#\a #\b))))


### PR DESCRIPTION
Implements most of Racket's printing and formatting functionality:

* `print` / `write` / `display` for all Primitives with support for all `print` arguments and `print-as-expression`.
* `format` and `fprintf`.
* `current-print`, used by error formatting.

---

@vishesh I know you'd prefer a RacketScript implementation for `fprintf`, but this has a JavaScript one. Still, having a working JS implementation to refer to will be helpful when implementing a RacketScript one.

The `format` and `current-print` / `error` functionality could in theory be split out as separate PRs, but it would be too much needless work in this case as the implementations are quite related.

/cc @stchang