### PR TITLE
Fix broken HTDP libs

### DIFF
--- a/racketscript-extras/racketscript/htdp/image.rkt
+++ b/racketscript-extras/racketscript/htdp/image.rkt
@@ -460,10 +460,9 @@
 (define-proto Bitmap
   (λ (data)
     #:with-this this
-    (define self #js.this)
     (define image (new #js*.Image))
     (:= #js.image.src (js-string data))
-    (set-object! self
+    (set-object! this
                  [image  image]
                  [width  #js.image.width]
                  [height #js.image.height]))

--- a/racketscript-extras/racketscript/htdp/universe.rkt
+++ b/racketscript-extras/racketscript/htdp/universe.rkt
@@ -72,10 +72,9 @@
    (λ ()
      #:with-this this
      (define active-handlers #js.this.-active-handlers)
-     (define self this)
      (let loop ([handlers #js.this.handlers])
        (when (pair? handlers)
-         (define h ((car handlers) self))
+         (define h ((car handlers) this))
          (#js.h.register)
          (:= ($ active-handlers #js.h.name) h)
          (loop (cdr handlers)))))]
@@ -138,7 +137,6 @@
    (λ ()
      #:with-this this
      (define events #js.this.-events)
-     (define self this)
 
      (:= #js.this.-idle #f)
 
@@ -146,18 +144,18 @@
        (cond
          [(> #js.events.length 0)
           (define evt         (#js.events.shift))
-          (define handler     ($ #js.self.-active-handlers #js.evt.type))
+          (define handler     ($ #js.this.-active-handlers #js.evt.type))
 
           (define changed?
             (cond
-              [handler (#js.handler.invoke #js.self.world evt)]
+              [handler (#js.handler.invoke #js.this.world evt)]
               [(equal? #js.evt.type #js"raw")
-               (#js.evt.invoke #js.self.world evt)]
+               (#js.evt.invoke #js.this.world evt)]
               [else
                (#js.console.warn "ignoring unknown/unregistered event type: " evt)]))
           (loop (or world-changed? changed?))]
-         [(and world-changed? (not #js.self.-stopped))
-          (#js.self.queue-event ($/obj [type #js"to-draw"]))
+         [(and world-changed? (not #js.this.-stopped))
+          (#js.this.queue-event ($/obj [type #js"to-draw"]))
           (loop #f)]))
 
      (:= #js.this.-idle #t))])
@@ -226,11 +224,10 @@
                                        [x    ($ posn 'x)]
                                        [y    ($ posn 'y)]))))
 
-        (define self this) ;; TODO: is this needed?
         (define (register-listener evt-name r-evt-name)
           (define cb (make-listener r-evt-name))
           (#js.canvas.addEventListener evt-name cb)
-          (:= ($ #js.self.listeners evt-name) cb))
+          (:= ($ #js.this.listeners evt-name) cb))
 
         (register-listener #js"mousemove"  #js"move")
         (register-listener #js"mousedown"  #js"button-down")
@@ -241,9 +238,8 @@
      [deregister
       (λ ()
         #:with-this this
-        (define self this)
         (define (remove-listener evt-name)
-          (define cb ($ #js.self.listeners evt-name))
+          (define cb ($ #js.this.listeners evt-name))
           (#js.bb.-canvas.removeEventListener evt-name cb))
         (remove-listener #js"mousemove")
         (remove-listener #js"mousedown")

--- a/racketscript-extras/racketscript/private/jscommon.rkt
+++ b/racketscript-extras/racketscript/private/jscommon.rkt
@@ -24,7 +24,8 @@
          max
          min
          twice
-         half)
+         half
+         (rename-out [field-λ λ]))
 
 ;;-----------------------------------------------------------------------------
 ;; Interop helpers
@@ -39,6 +40,14 @@
   (define-syntax-class field
     #:description "a key-value pair for object"
     (pattern [name:id val:expr])))
+
+(define-syntax (field-λ stx)
+  (syntax-parse stx
+    [(_ formals (~datum #:with-this) self:id body ...)
+     #'(λ formals
+         (define self *this*)
+         body ...)]
+    [(_ formals body ...) #'(λ formals body ...)]))
 
 (define-syntax (define-proto stx)
   (syntax-parse stx


### PR DESCRIPTION
HTDP got broken after changes after improvements to identifier normalization improvements (expect more breaks :( in future around code that use FFI).

I'm putting this on CR to get some feedback on how to handle `this` stuff in JavaScript in future from RacketScript. Its not a safe thing to use, and particularly when you are using it in a callback. What this patch does is to extend[1] lambda's bind `this` with a variable, which will make it safe to use in callbacks and so.

Should we encourage something like this in our FFI  whenever `this` is involved? There will always be raw low-level `this` available if one actually needs that.

[1] https://github.com/vishesh/racketscript/compare/develop...task/fix-htdp-libs?expand=1#diff-6a9c6fd3ed8118a4107bf70798eb983bR47

@stchang @glebm 
