### PR TITLE
string->number support

### DIFF
--- a/racketscript-compiler/racketscript/compiler/runtime/core/unicode_string.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/unicode_string.js
@@ -232,6 +232,35 @@ export class UString extends Primitive /* implements Printable */ {
     printUString(out) {
         this.writeUString(out);
     }
+
+    /**
+     * Whether the string can be parsed as an integer as defined by
+     * Racket's string->number.
+     *
+     * @param {!number} radix an integer in [2, 16] range.
+     * @return {!boolean}
+     */
+    isValidInteger(radix) {
+        const chars = this.chars;
+        const startFrom = chars[0].codepoint === /* '-' */ 45 ? 1 : 0;
+        if (radix > 10) {
+            const maxLowercase = /* 'a' - 11 */ 86 + radix;
+            const maxUppercase = maxLowercase - 32;
+            for (let i = startFrom; i < chars.length; ++i) {
+                let cp = chars[i].codepoint;
+                if (cp < /* '0' */ 48 || cp > maxLowercase ||
+                    cp > maxUppercase && cp < /* 'a' */ 97 ||
+                    cp > /* '9' */ 57 && cp < /* 'A' */ 65) return false;
+            }
+        } else {
+            const max = /* '0' - 1 */ 47 + radix;
+            for (let i = startFrom; i < chars.length; ++i) {
+                let cp = chars[i].codepoint;
+                if (cp < /* '0' */ 48 || cp > max) return false;
+            }
+        }
+        return true;
+    }
 }
 
 /**

--- a/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
+++ b/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
@@ -659,6 +659,20 @@
 (define-checked+provide (string->uninterned-symbol [s string?])
   (#js.Core.Symbol.makeUninterned s))
 
+; Does not support prefixed forms such as "#b101".
+(define+provide (string->number s [radix 10])
+  (define (integer-in lo hi)
+    (v-λ (v) #:unchecked
+      (and (exact-integer? v) (>= v lo) (<= v hi))))
+  (check/raise string? s 0)
+  (check/raise (integer-in 2 16) radix 1)
+  (let ([result (#js*.parseInt s radix)])
+    (if (or (#js*.isNaN result)
+            ; Work around parseInt permissiveness.
+            (not (#js.s.isValidInteger radix)))
+      #f
+      result)))
+
 (define-checked+provide (symbol-interned? [sym symbol?])
   ;;NOTE: We simply check if given symbol is equal to an
   ;; interned symbol.

--- a/tests/basic/string.rkt
+++ b/tests/basic/string.rkt
@@ -38,6 +38,20 @@
 (displayln (string-append "Hello" "World" "🎂"))
 (displayln (immutable? (string-append "a" "🎂")))
 
+; Valid string->number arguments
+(displayln (string->number "123"))
+(displayln (string->number "-123"))
+(displayln (string->number "A"))
+(displayln (string->number "AFe1" 16))
+(displayln (string->number "1101" 2))
+
+; Invalid string->number arguments
+(displayln (string->number " 123"))
+(displayln (string->number "123x"))
+(displayln (string->number "2" 2))
+(displayln (string->number "" 2))
+(displayln (string->number " "))
+
 ;; These don't work because RacketScript cannot yet handle racket/string.
 ; (displayln (car (string-split "Hello+World" "+")))
 ; (displayln (immutable? (car (string-split "Hello+World" "+"))))


### PR DESCRIPTION
Adds a basic `string->number` implementation.
Does not support prefix forms ("#b101") nor arguments other than `radix`.