### PR TITLE
Implement more char functions

### DIFF
--- a/racketscript-compiler/racketscript/compiler/js-support/traceur/gulpfile.js
+++ b/racketscript-compiler/racketscript/compiler/js-support/traceur/gulpfile.js
@@ -14,7 +14,7 @@ gulp.task('copy-hamt', function() {
 
 gulp.task('build', gulp.series('copy-hamt', function() {
     return gulp.src('modules/' + target)
-	.pipe(traceur({modules: 'inline'}))
+	.pipe(traceur({modules: 'inline', outputLanguage: 'es6'}))
         .pipe(concat('compiled.js'))
         //.pipe(uglify())
 	.pipe(gulp.dest('dist'));

--- a/racketscript-compiler/racketscript/compiler/runtime/core/unicode_string.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/unicode_string.js
@@ -187,7 +187,7 @@ export class UString extends Primitive /* implements Printable */ {
                 out.consume('\\\\');
                 break;
             default:
-                if (Char.isGraphicCodepoint(c) || Char.isBlankCodepoint(c)) {
+                if (Char.isGraphic(char) || Char.isBlank(char)) {
                     out.consume(char.toString());
                 } else {
                     out.consume(c > 0xFFFF

--- a/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
+++ b/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
@@ -855,6 +855,45 @@
 (define-checked+provide (char-utf-8-length [c char?])
   (#js.Core.Char.charUtf8Length c))
 
+(define-checked+provide (char-upcase [c char?])
+  (#js.Core.Char.upcase c))
+
+(define-checked+provide (char-downcase [c char?])
+  (#js.Core.Char.downcase c))
+
+(define-checked+provide (char-alphabetic? [c char?])
+  (#js.Core.Char.isAlphabetic c))
+
+(define-checked+provide (char-lower-case? [c char?])
+  (#js.Core.Char.isLowerCase c))
+
+(define-checked+provide (char-upper-case? [c char?])
+  (#js.Core.Char.isUpperCase c))
+
+(define-checked+provide (char-title-case? [c char?])
+  (#js.Core.Char.isTitleCase c))
+
+(define-checked+provide (char-numeric? [c char?])
+  (#js.Core.Char.isNumeric c))
+
+(define-checked+provide (char-symbolic? [c char?])
+  (#js.Core.Char.isSymbolic c))
+
+(define-checked+provide (char-punctuation? [c char?])
+  (#js.Core.Char.isPunctuation c))
+
+(define-checked+provide (char-graphic? [c char?])
+  (#js.Core.Char.isGraphic c))
+
+(define-checked+provide (char-whitespace? [c char?])
+  (#js.Core.Char.isWhitespace c))
+
+(define-checked+provide (char-blank? [c char?])
+  (#js.Core.Char.isBlank c))
+
+(define-checked+provide (char-iso-control? [c char?])
+  (#js.Core.Char.isIsoControl c))
+
 ; TODO: Add varargs support for the comparison methods below.
 
 (define-checked+provide (char<? [a char?] [b char?])

--- a/tests/basic/char.rkt
+++ b/tests/basic/char.rkt
@@ -44,6 +44,79 @@
 (println #\a)
 (println #\tab)
 (println #\߆)
+(println #\🎂)
 
-; This test requires a full implementation of isGraphicCodepoint to pass.
-; (println #\🎂)
+(println (char-upcase #\a))
+(println (char-upcase #\ß))
+(println (char-upcase #\ﬁ))  ; upper case is longer than 1 character (FI).
+(println (char-downcase #\A))
+(println (char-downcase #\ẞ))
+
+;; Not implemented:
+; (println (char-titlecase #\a))
+; (println (char-foldcase #\A))
+; (println (char-foldcase #\ß))
+; (println (char-foldcase #\ß))
+
+(displayln "char-alphabetic-case?")
+(println (char-alphabetic? #\A))
+(println (char-alphabetic? #\Я))
+(println (char-alphabetic? #\tab))
+
+(displayln "char-lower-case?")
+(println (char-lower-case? #\A))
+(println (char-lower-case? #\a))
+(println (char-lower-case? #\Я))
+(println (char-lower-case? #\я))
+(println (char-lower-case? #\5))
+
+(displayln "char-upper-case?")
+(println (char-upper-case? #\A))
+(println (char-upper-case? #\a))
+(println (char-upper-case? #\Я))
+(println (char-upper-case? #\Я))
+(println (char-upper-case? #\5))
+
+(displayln "char-title-case?")
+(println (char-title-case? #\A))
+(println (char-title-case? #\a))
+(println (char-title-case? #\Я))
+(println (char-title-case? #\Я))
+(println (char-title-case? #\5))
+
+(displayln "char-numeric?")
+(println (char-numeric? #\5))  ; Nd
+(println (char-numeric? #\Ⅻ))  ; Nl
+(println (char-numeric? #\㊲))  ; No
+
+(displayln "char-symbolic?")
+(println (char-symbolic? #\A))
+(println (char-symbolic? #\∄))
+
+(displayln "char-punctuation?")
+(println (char-punctuation? #\A))
+(println (char-punctuation? #\;))
+
+(displayln "char-graphic?")
+(println (char-graphic? #\A))
+(println (char-graphic? #\🎂))
+(println (char-graphic? #\㊲))
+(println (char-graphic? #\tab))
+
+(displayln "char-whitespace?")
+(println (char-whitespace? #\A))
+(println (char-whitespace? #\space))
+(println (char-whitespace? #\newline))
+(println (char-whitespace? #\tab))
+
+(displayln "char-blank?")
+(println (char-blank? #\A))
+(println (char-blank? #\space))
+(println (char-blank? #\newline))
+(println (char-blank? #\tab))
+
+(displayln "char-iso-control?")
+(println (char-iso-control? #\A))
+(println (char-iso-control? #\nul))
+(println (char-iso-control? #\rubout))
+(println (char-iso-control? #\u9F))


### PR DESCRIPTION
1. All `char-*?` Unicode property test methods.
2. `char-upcase` and `char-downcase`.

Fixes #170