### PR TITLE
@stchang add another freshen pass, between expand and absyn, to handle generated dup racket ids

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,13 @@ sudo: false
 env:
   global:
     - RACKET_DIR=~/racket
-    - RACKET_RUN_COVERAGE=7.5
+    - RACKET_RUN_COVERAGE=7.6
   matrix:
     - RACKET_VERSION=HEAD
     - RACKET_VERSION=RELEASE
+    - RACKET_VERSION=7.8
+    - RACKET_VERSION=7.7
+    - RACKET_VERSION=7.6
     - RACKET_VERSION=7.5
     - RACKET_VERSION=7.4
     - RACKET_VERSION=7.0

--- a/racketscript-compiler/racketscript/compiler/runtime/kernel.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/kernel.js
@@ -285,25 +285,6 @@ export function findf(f, lst) {
     return false;
 }
 
-
-// TODO: more faithfully reproduce Racket sort?
-// this implements raw-sort from #%kernel, see racket/private/list
-// export function sort9(lst, cmp) {
-//     const arr = Core.Pair.listToArray(lst);
-//     const x2i = new Map();
-//     arr.forEach((x, i) => { x2i.set(x, i); });
-//     const srted = arr.sort((x, y) => {
-//         if (cmp(x, y)) {
-//             return -1;
-//         } else if (cmp(y, x)) {
-//             return 1;
-//         } // x = y, simulate stable sort by comparing indices
-//         return x2i.get(x) - x2i.get(y);
-//     });
-
-//     return Core.Pair.listFromArray(srted);
-// }
-
 export function assv(k, lst) {
     while (Core.Pair.isEmpty(lst) === false) {
         if (Core.isEqv(k, lst.hd.hd)) {

--- a/racketscript-compiler/racketscript/compiler/runtime/kernel.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/kernel.js
@@ -288,21 +288,21 @@ export function findf(f, lst) {
 
 // TODO: more faithfully reproduce Racket sort?
 // this implements raw-sort from #%kernel, see racket/private/list
-export function sort9(lst, cmp) {
-    const arr = Core.Pair.listToArray(lst);
-    const x2i = new Map();
-    arr.forEach((x, i) => { x2i.set(x, i); });
-    const srted = arr.sort((x, y) => {
-        if (cmp(x, y)) {
-            return -1;
-        } else if (cmp(y, x)) {
-            return 1;
-        } // x = y, simulate stable sort by comparing indices
-        return x2i.get(x) - x2i.get(y);
-    });
+// export function sort9(lst, cmp) {
+//     const arr = Core.Pair.listToArray(lst);
+//     const x2i = new Map();
+//     arr.forEach((x, i) => { x2i.set(x, i); });
+//     const srted = arr.sort((x, y) => {
+//         if (cmp(x, y)) {
+//             return -1;
+//         } else if (cmp(y, x)) {
+//             return 1;
+//         } // x = y, simulate stable sort by comparing indices
+//         return x2i.get(x) - x2i.get(y);
+//     });
 
-    return Core.Pair.listFromArray(srted);
-}
+//     return Core.Pair.listFromArray(srted);
+// }
 
 export function assv(k, lst) {
     while (Core.Pair.isEmpty(lst) === false) {

--- a/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
+++ b/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
@@ -691,7 +691,6 @@
 (define+provide memq #js.Kernel.memq)
 (define+provide memf #js.Kernel.memf)
 (define+provide findf #js.Kernel.findf)
-;(define+provide sort9 #js.Kernel.sort9)
 (define+provide assv #js.Kernel.assv)
 (define+provide assq #js.Kernel.assq)
 (define+provide assf #js.Kernel.assf)

--- a/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
+++ b/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
@@ -691,7 +691,7 @@
 (define+provide memq #js.Kernel.memq)
 (define+provide memf #js.Kernel.memf)
 (define+provide findf #js.Kernel.findf)
-(define+provide sort9 #js.Kernel.sort9)
+;(define+provide sort9 #js.Kernel.sort9)
 (define+provide assv #js.Kernel.assv)
 (define+provide assq #js.Kernel.assq)
 (define+provide assf #js.Kernel.assf)


### PR DESCRIPTION
this fixes all tests up to and including racket 7.8