### PR TITLE
delete jshint and ts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,8 @@
 .PHONY: build setup setup-extra clean
 .PHONY: test unit-test integration-test test
 .PHONY: coverage coverage-unit-test
-.PHONY: eslint eslint-fix jshint tscheck
+.PHONY: eslint eslint-fix
 
-TSC=node_modules/typescript/bin/tsc
 ESLINT=node_modules/eslint/bin/eslint.js
 
 ## Compile recipes
@@ -33,7 +32,7 @@ setup:
 		    raco pkg update --link racketscript-extras/
 
 setup-extra:
-	npm install -g js-beautify eslint jshint gulp
+	npm install -g js-beautify eslint gulp
 	raco pkg install --auto cover
 
 clean:
@@ -62,16 +61,6 @@ eslint: | node_modules
 
 eslint-fix: | node_modules
 	$(ESLINT) --fix ./racketscript-compiler/racketscript/compiler/runtime/
-
-jshint:
-	@echo "    RACKETSCRIPT RUNTIME LINT    "
-	@echo "++++++++++++++++++++++++++++"
-	jshint ./racketscript-compiler/racketscript/compiler/runtime/ || true
-
-# Typecheck JavaScript
-tscheck: node_modules
-	$(TSC) --noEmit --allowJs --checkJs --strict --lib es2017 --target es2017 \
-	racketscript-compiler/racketscript/compiler/runtime/kernel.js
 
 node_modules: package.json
 	npm install

--- a/package.json
+++ b/package.json
@@ -1,7 +1,4 @@
 {
-  "dependencies": {
-    "typescript": "^2.5.2"
-  },
   "devDependencies": {
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^12.0.0",


### PR DESCRIPTION
We don't need them because:
1. JSHint is out of date. We can use ESLint for linting javascript
   code
2. TypeScript is useful but to use it we need to add types. Without them,
   we can't rely on TS checks.