### PR TITLE
switch to using `links` fn (from setup/link) to process collection links

### DIFF
--- a/.github/workflows/racket.yml
+++ b/.github/workflows/racket.yml
@@ -15,19 +15,19 @@ jobs:
       fail-fast: false 
       matrix:
         racket-version: [ '6.12', '7.0', '7.4', '7.5', '7.6', '7.7', '7.8' ]
-	racket-variant: [ 'BC' ]
+        racket-variant: [ 'BC' ]
         experimental: [false]
         include:
           - racket-version: '8.0'
-	    racket-variant: 'CS'
+            racket-variant: 'CS'
             experimental: true
           - racket-version: '8.1'
-	    racket-variant: 'CS'
+            racket-variant: 'CS'
             experimental: true
           - racket-version: 'current'
-	    racket-variant: 'CS'
+            racket-variant: 'CS'
             experimental: true
-    name: Racket ${{ matrix.racket-variant }} ${{ matrix.racket-version }}
+    name: Racket ${{ matrix.racket-version }} ${{ matrix.racket-variant }}
     steps:
       - uses: actions/checkout@master
       - name: Setup Racket

--- a/.github/workflows/racket.yml
+++ b/.github/workflows/racket.yml
@@ -15,22 +15,27 @@ jobs:
       fail-fast: false 
       matrix:
         racket-version: [ '6.12', '7.0', '7.4', '7.5', '7.6', '7.7', '7.8' ]
+	racket-variant: [ 'BC' ]
         experimental: [false]
         include:
           - racket-version: '8.0'
+	    racket-variant: 'CS'
             experimental: true
           - racket-version: '8.1'
+	    racket-variant: 'CS'
             experimental: true
           - racket-version: 'current'
+	    racket-variant: 'CS'
             experimental: true
-    name: Racket ${{ matrix.racket-version }}
+    name: Racket ${{ matrix.racket-variant }} ${{ matrix.racket-version }}
     steps:
       - uses: actions/checkout@master
       - name: Setup Racket
-        uses: Bogdanp/setup-racket@v1.3.1
+        uses: Bogdanp/setup-racket@v1.4
         with:
           architecture: 'x64'
           version: ${{ matrix.racket-version }}
+          variant: ${{ matrix.racket-variant }}
       - run: raco pkg install --auto -t dir racketscript-compiler/
       - run: make unit-test
       - run: make integration-test

--- a/racketscript-compiler/racketscript/compiler/util-untyped.rkt
+++ b/racketscript-compiler/racketscript/compiler/util-untyped.rkt
@@ -31,7 +31,9 @@
 ;; else return false.
 (define (links-module? mod-path)
   (define links-file (find-links-file))
-  (for/or ([link-path (links #:file links-file #:root? #t)])
+  (for*/or ([links-file (current-library-collection-links)]
+            #:when links-file
+            [link-path (links #:file links-file #:root? #t)])
     (and (subpath? link-path mod-path)
          (let-values ([(base link-name dir?) (split-path link-path)])
            (list (~a link-name) link-path)))))

--- a/racketscript-compiler/racketscript/compiler/util-untyped.rkt
+++ b/racketscript-compiler/racketscript/compiler/util-untyped.rkt
@@ -30,93 +30,11 @@
 ;;         #<path:/home/username/racketscript/racketscript-compiler>)
 ;; else return false.
 (define (links-module? mod-path)
-;  (printf "links-module? mod-path: ~v\n" mod-path)
   (define links-file (find-links-file))
   (for/or ([link-path (links #:file links-file #:root? #t)])
-    ;; (printf "link: ~v\n" link)
-    ;; (define link-name
-    ;;   (~a (let-values ([(base last dir?) (split-path link-path)]) last)))
-    ;; (printf "link-name: ~v\n" link-name)
-    ;; (printf "link-path: ~v\n" link-path)
     (and (subpath? link-path mod-path)
-#;         (printf "link result: ~v\n" 
-                   (list link-name link-path))
          (let-values ([(base link-name dir?) (split-path link-path)])
            (list (~a link-name) link-path)))))
-
-#;(define (links-module? mod-path)
-  (printf "links-module? mod-path: ~v\n" mod-path)
-  (define (match-link? dir link)
-    (printf "match-link?: ~v\n" dir)
-    (printf "match-link?: ~v\n" link)
-    (match link
-      [(list 'root path) #:when (absolute-path? path)
-       ;; Links.rktd may have point to root package which is not at current
-       ;; subdir. Eg. /usr/local/.../links.rktl may point to a package in
-       ;; home directory.
-       (subpath? (~a (simplify-path path))
-                 (~a mod-path))]
-      [(list name path)
-       (printf "match-link? link name: ~v\n" name)
-       (printf "match-link? link path: ~v\n" path)
-       (subpath? (~a (simplify-path (build-path dir path)))
-                 (~a mod-path))]
-      [(list name path re) #f]))
-
-  ;; Path LinkEntry -> (list Symbol Path)
-  ;; Returns (list link-name pkg-root-dir)
-  ;; WHERE: LinkEntry is  an entry in links.rktd file
-  (define (link->result link-fpath link)
-    (printf "link->result: ~a\n" link-fpath)
-    (printf "link->result: ~a\n" link)
-    ;; HACK: If the link path is relative path, then we pick
-    ;; the last component
-    (define (fix-relative-path p)
-      (if (relative-path? p)
-          (~a (let-values ([(base last dir?) (split-path p)]) last))
-          p))
-    (match link
-      [(list 'root path) #:when (absolute-path? path)
-       (list (~a (let-values ([(base last dir?) (split-path path)]) last))
-             (string->path path))]
-      [(list name path)
-       (list (if (symbol? name)
-                 (fix-relative-path path)
-                 name)
-             (simplify-path (build-path (path-only link-fpath)
-                                        path)))]
-      [_ (error 'link->result "unsupported form")]))
-
-  ;; Path -> (list Symbol Path)
-  ;; Iterate through each entry in links.rktd file pointed
-  ;; by link-fpath and find the entry with module mod-path
-  (define (find-link link-fpath)
-    (log-rjs-debug "Processing library collection links at: ~a" link-fpath)
-    (define links-dir (path-only link-fpath))
-    (cond
-      [(file-exists? link-fpath)
-       (call-with-input-file link-fpath
-         (λ (p-links-in)
-           (let loop ([links (read p-links-in)])
-             (printf "links: ~v\n" links)
-             (match links
-               ['() #f]
-               [(cons hd tl) (if (match-link? links-dir hd)
-                                 (link->result link-fpath hd)
-                                 (loop tl))]))))]
-      [else
-       (log-rjs-warning "Library collection link file ~a does not exist!" link-fpath)
-       #f]))
-
-  ;; Iterate through each links.rktd file, to find
-  ;; the out
-  (let loop ([links (current-library-collection-links)])
-    (match links
-      ['() #f]
-      [(cons #f tl) (loop tl)]
-      [(cons hd tl) (or (find-link hd)
-                        (loop tl))])))
-
 
 (define (improper->proper l)
   (match l

--- a/tests/racket-core/hash.rkt
+++ b/tests/racket-core/hash.rkt
@@ -596,7 +596,7 @@
 
 (run-if-version "8.1.0.1" ; racket cs changed err msgs, see pr#3838
   ;; also, hash-set err changed to use and/c instead of and in 8.0
-  (err/rt-test (hash-set (make-hash) 1 2))
+  (err/rt-test (hash-set (make-hash) 1 2) exn:fail:contract? "hash\\? immutable")
   (err/rt-test (hash-remove (make-hash) 1))
   (err/rt-test (hash-set! (hash) 1 2))
   (err/rt-test (hash-remove! (hash) 1)))


### PR DESCRIPTION
- this fixes the tests when using Racket HEAD, see #200
- was previously breaking due to new use of "encoded paths" in links.rktd
    - see racket commit 2ac7e21ad422ee322daa4a7e0db318f9b72b6c48