### PR TITLE
feat: add changelog auto-generation

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,25 @@
+name: changelog
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout branch
+      uses: actions/checkout@v1
+    - name: Use Node.js 10
+      uses: actions/setup-node@v1
+    - name: Install github-release-notes and generate changelog
+      run: |
+        npx github-release-notes@0.17.1 changelog --generate --override --token=${{ secrets.CHANGELOG_TOKEN }} --changelog-filename=TEMP_CHANGELOG.md
+      env:
+        CI: true
+    - name: Create and publish realese
+      uses: ncipollo/release-action@v1
+      with:
+        bodyFile: 'TEMP_CHANGELOG.md'
+        token: ${{ secrets.CHANGELOG_TOKEN }}

--- a/.grenrc
+++ b/.grenrc
@@ -1,0 +1,11 @@
+{
+  "dataSource": "commits",
+  "includeMessages": "commits",
+  "changelogFilename": "CHANGELOG.md",
+  "onlyMilestones": false,
+  "ignoreIssuesWith": [
+    "wontfix",
+    "duplicate"
+  ]
+}
+


### PR DESCRIPTION
Here a GH action config for changelog generation. It'll help to create release notes for every pushed tag (here you can see how it works https://github.com/github-tools/github-release-notes/releases). 

And by changing a source of the racketscript package here https://pkgs.racket-lang.org/package/racketscript from this pattern `https://github.com/‹user›/‹package›.git` to this one `https://github.com/‹user›/‹package›.git#tag` (see "GitHub Deployment" here https://docs.racket-lang.org/pkg/getting-started.html#%28part._github-deploy%29) we'll allow to install a particular version of racketscript.

Resolves: https://github.com/vishesh/racketscript/issues/193

But to make it work @vishesh should create CHANGELOG_TOKEN (see https://github.com/github-tools/github-release-notes#setup) and change the source path of the package.