### PR TITLE
Prepare proper module dependency graph when taking module from stdin

### DIFF
--- a/racketscript-compiler/racketscript/compiler/expand.rkt
+++ b/racketscript-compiler/racketscript/compiler/expand.rkt
@@ -310,7 +310,7 @@
                                             nom-src-mod-path-orig
                                             mod-src-id))]))
 
-           ;; If the moduele is renamed use the id name used at the importing
+           ;; If the module is renamed use the id name used at the importing
            ;; module rather than defining module. Since renamed, module currently
            ;; are #%kernel which we write ourselves in JS we prefer original name.
            ;; TODO: We potentially might have clashes, but its unlikely.
@@ -458,7 +458,7 @@
 (define (to-absyn/top stx)
   (to-absyn stx))
 
-(define (do-expand stx in-path)
+(define (do-expand stx)
   ;; error checking
   (syntax-parse stx
     [((~and mod-datum (~datum module)) n:id lang:expr . rest)
@@ -490,21 +490,12 @@
   (read-accept-lang #t)
   (define full-path (path->complete-path (actual-module-path in-path)))
   (parameterize ([current-directory (path-only full-path)])
-    (do-expand (open-read-module in-path) in-path)))
+    (do-expand (open-read-module in-path))))
 
 (define (read-and-expand-module input)
   (read-accept-reader #t)
   (read-accept-lang #t)
-  ;; Just give it any name for now
-  (define full-path
-    (match (object-name input)
-      ['stdin (main-source-file)]
-      [v (path->complete-path v)]))
-  (define new-cwd (if full-path
-                      (path-only full-path)
-                      (current-directory)))
-  (parameterize ([current-directory new-cwd])
-    (do-expand (read-syntax (object-name input) input) full-path)))
+  (do-expand (read-syntax (object-name input) input)))
 
 ;;;----------------------------------------------------------------------------
 ;;; Flatten Phases in Module
@@ -994,4 +985,3 @@
 
     (check-equal? (map syntax-e (get-quoted-bindings test-mod-1))
                   '(internal-func))))
-

--- a/racketscript-compiler/racketscript/compiler/moddeps.rkt
+++ b/racketscript-compiler/racketscript/compiler/moddeps.rkt
@@ -71,12 +71,12 @@
            [#f (result src* id*)]
            ['() #f]))))
 
-;; ModulePath -> ExportTree
+;; (Listof ModulePath) -> ExportTree
 ;; Return whole tree of exports with its source starting
-;; from mod-name (ModulePath)
-(define (get-export-tree mod-name)
+;; with given list of modules 'mods'.
+(define (get-export-tree mods)
   (define modules (filter-not symbol? (module-deps/tsort-inv
-                                       (get-module-deps mod-name))))
+                                       (get-module-deps mods))))
   (for/hash ([m (append (set->list primitive-modules) modules)])
     (values m (get-exports/modpath m))))
 
@@ -129,9 +129,9 @@
       (transpose _)
       (tsort _)))
 
-;; Path -> (Map Path (Listof Path))
-;; Returns a adjecency map of module imports
-(define (get-module-deps mod-path)
+;; (Listof Path) -> (Map Path (Listof Path))
+;; Returns a adjacency map of module imports.
+(define (get-module-deps mod-paths)
   (define graph (make-hash))
   (define (build-graph mod-path)
     (define path (resolve-module-path mod-path #f))
@@ -150,5 +150,7 @@
                            (hash-update! graph path (λ (v) (cons new-mod v)))
                            (unless (hash-ref graph new-mod #f)
                              (build-graph new-mod))]))))
-  (build-graph mod-path)
+  (for ([path mod-paths])
+    (build-graph path))
+
   graph)

--- a/racketscript-compiler/racketscript/compiler/nothing.rkt
+++ b/racketscript-compiler/racketscript/compiler/nothing.rkt
@@ -1,3 +1,0 @@
-#lang racket
-
-(require "../interop.rkt")

--- a/tests/fixture.rkt
+++ b/tests/fixture.rkt
@@ -105,7 +105,7 @@
 ;; Path-String -> ExportTree
 (define get-cached-export-tree
   (memoized-λ (test-fpath)
-    (get-export-tree test-fpath)))
+    (get-export-tree (list test-fpath))))
 
 ;; Path-String -> Void
 ;; Compile test-case in `fpath` to JavaScript


### PR DESCRIPTION
Currently, we relied on a stub "nothing.rkt", but we should instead look at the
imported modules itself. This should fix the the 'undefined identifier' issues
we keep getting in Playground.

FIXES #134