### PR TITLE
feat: provide `js-object?` and fix it

### DIFF
--- a/racketscript-compiler/racketscript/interop.rkt
+++ b/racketscript-compiler/racketscript/interop.rkt
@@ -26,6 +26,7 @@
          (rename-out [*in-js-array in-js-array]
                      [*in-js-object in-js-object])
          for/js-array
+         js-array?
          for/js-object
          js-object?)
 
@@ -253,7 +254,7 @@
   ($ arr 'length i))
 
 (define (js-array? v)
-  ($/instanceof v ($ 'Array)))
+  (($ ($ 'Array) 'isArray) v))
 
 (define (in-js-array arr)
   (check-array arr)

--- a/racketscript-compiler/racketscript/interop.rkt
+++ b/racketscript-compiler/racketscript/interop.rkt
@@ -26,7 +26,8 @@
          (rename-out [*in-js-array in-js-array]
                      [*in-js-object in-js-object])
          for/js-array
-         for/js-object)
+         for/js-object
+         js-object?)
 
 (require syntax/parse/define
          (for-syntax syntax/parse
@@ -300,7 +301,7 @@
   (for/list ([(k v) (*in-js-object obj)]) (values k v)))
 
 (define (js-object? v)
-  ($/typeof v "object"))
+  (and ($/typeof v "object") (not (eq? v $/null))))
 
 (define (check-object v)
   (unless (js-object? v)


### PR DESCRIPTION
js-object? is a useful function for js integrations so I think it's better to provide it. And we need to check if `v` is not null because:

```js
typeof null // object
```

and I did the same with `js-array?`. And replaced `instanceof` with `Array.isArray` (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray#instanceof_vs_isarray)