### PR TITLE
fix: check if js object is not a racket primitive

### DIFF
--- a/racketscript-compiler/racketscript/interop.rkt
+++ b/racketscript-compiler/racketscript/interop.rkt
@@ -302,7 +302,11 @@
   (for/list ([(k v) (*in-js-object obj)]) (values k v)))
 
 (define (js-object? v)
-  (and ($/typeof v "object") (not (eq? v $/null))))
+  ($/binop &&
+    ($/binop &&
+      ($/typeof v "object")
+      ($/binop !== v $/null))
+    (not (($ ($ '$rjs_core) 'Primitive 'check) v))))
 
 (define (check-object v)
   (unless (js-object? v)


### PR DESCRIPTION
Without the fix it works like that:

```lisp
(js-object? ($/obj (test "test"))) // #t
(js-object? "test") // #t
```